### PR TITLE
Add cmake and solc flag to control the default mode of compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(SOLC_LINK_STATIC "Link solc executable statically on supported platforms"
 option(SOLC_STATIC_STDLIBS "Link solc against static versions of libgcc and libstdc++ on supported platforms" OFF)
 option(STRICT_Z3_VERSION "Use the latest version of Z3" ON)
 option(PEDANTIC "Enable extra warnings and pedantic build flags. Treat all warnings as errors." ON)
+option(ZKEVM_MODE_BY_DEFAULT "Enable ZKEVM mode by default" ON)
 
 # Setup cccache.
 include(EthCcache)

--- a/liblangutil/CMakeLists.txt
+++ b/liblangutil/CMakeLists.txt
@@ -32,3 +32,7 @@ set(sources
 
 add_library(langutil ${sources})
 target_link_libraries(langutil PUBLIC solutil fmt::fmt-header-only)
+
+if(NOT ZKEVM_MODE_BY_DEFAULT)
+	target_compile_definitions(langutil PRIVATE DISABLE_ZKEVM_MODE_BY_DEFAULT)
+endif()

--- a/liblangutil/EVMVersion.cpp
+++ b/liblangutil/EVMVersion.cpp
@@ -25,6 +25,12 @@ using namespace solidity;
 using namespace solidity::evmasm;
 using namespace solidity::langutil;
 
+#ifdef DISABLE_ZKEVM_MODE_BY_DEFAULT
+bool solidity::langutil::g_zkEVM = false;
+#else
+bool solidity::langutil::g_zkEVM = true;
+#endif
+
 bool EVMVersion::hasOpcode(Instruction _opcode) const
 {
 	switch (_opcode)

--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -105,4 +105,6 @@ private:
 	Version m_version = Version::London;
 };
 
+extern bool g_zkEVM;
+
 }

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -48,6 +48,8 @@ static string const g_strEVM = "evm";
 static string const g_strEVMVersion = "evm-version";
 static string const g_strEwasm = "ewasm";
 static string const g_strViaIR = "via-ir";
+static string const g_strEnableZKEVMMode = "zkevm-mode";
+static string const g_strDisableZKEVMMode = "no-zkevm-mode";
 static string const g_strExperimentalViaIR = "experimental-via-ir";
 static string const g_strGas = "gas";
 static string const g_strHelp = "help";
@@ -584,6 +586,14 @@ General Information)").c_str(),
 		(
 			g_strViaIR.c_str(),
 			"Turn on compilation mode via the IR."
+		)
+		(
+			g_strEnableZKEVMMode.c_str(),
+			"Enable ZKEVM mode"
+		)
+		(
+			g_strDisableZKEVMMode.c_str(),
+			"Disable ZKEVM mode"
 		)
 		(
 			g_strRevertStrings.c_str(),
@@ -1277,6 +1287,14 @@ void CommandLineParser::processArgs()
 		m_args.count(g_strModelCheckerTargets) ||
 		m_args.count(g_strModelCheckerTimeout);
 	m_options.output.viaIR = (m_args.count(g_strExperimentalViaIR) > 0 || m_args.count(g_strViaIR) > 0);
+
+	if (m_args.count(g_strEnableZKEVMMode) > 0 && m_args.count(g_strDisableZKEVMMode) > 0)
+		solThrow(CommandLineValidationError, "zkevm mode cannot be both enabled and disabled");
+	if (m_args.count(g_strEnableZKEVMMode) > 0)
+		langutil::g_zkEVM = true;
+	else if (m_args.count(g_strDisableZKEVMMode) > 0)
+		langutil::g_zkEVM = false;
+
 	if (m_options.input.mode == InputMode::Compiler)
 		m_options.input.errorRecovery = (m_args.count(g_strErrorRecovery) > 0);
 


### PR DESCRIPTION
With this commit, solc enables the zkevm mode of compilation by default. This behavior can be changed with a new cmake flag.