### PR TITLE
Replace the gas stipend with an explicitly fetched value

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -783,13 +783,10 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		case FunctionType::Kind::Transfer:
 		{
 			_functionCall.expression().accept(*this);
-			// Provide the gas stipend manually at first because we may send zero ether.
-			// Will be zeroed if we send more than zero ether.
-			m_context << u256(evmasm::GasCosts::callStipend);
+			// Unlike evm, 0 or GasCosts::callStipend constants doesn't make
+			// sense for zkevm
+			m_context << Instruction::GAS;
 			acceptAndConvert(*arguments.front(), *function.parameterTypes().front(), true);
-			// gas <- gas * !value
-			m_context << Instruction::SWAP1 << Instruction::DUP2;
-			m_context << Instruction::ISZERO << Instruction::MUL << Instruction::SWAP1;
 			FunctionType::Options callOptions;
 			callOptions.valueSet = true;
 			callOptions.gasSet = true;

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1529,15 +1529,13 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		string address{IRVariable(_functionCall.expression()).part("address").name()};
 		string value{expressionAsType(*arguments[0], *(parameterTypes[0]))};
 		Whiskers templ(R"(
-			let <gas> := 0
-			if iszero(<value>) { <gas> := <callStipend> }
+			let <gas> := gas()
 			let <success> := call(<gas>, <address>, <value>, 0, 0, 0, 0)
 			<?isTransfer>
 				if iszero(<success>) { <forwardingRevert>() }
 			</isTransfer>
 		)");
 		templ("gas", m_context.newYulVariable());
-		templ("callStipend", toString(evmasm::GasCosts::callStipend));
 		templ("address", address);
 		templ("value", value);
 		if (functionType->kind() == FunctionType::Kind::Transfer)


### PR DESCRIPTION
This commit gets the compiler to emit gas() for calls lowered from send/transfer of address payables.