### PR TITLE
yul-optimiser: Always try to evaluate keccak256

### DIFF
--- a/libyul/optimiser/LoadResolver.cpp
+++ b/libyul/optimiser/LoadResolver.cpp
@@ -120,24 +120,6 @@ void LoadResolver::tryEvaluateKeccak(
 		m_expectedExecutionsPerDeployment ? *m_expectedExecutionsPerDeployment : 1
 	};
 
-	bigint costOfKeccak = gasMeter.costs(_e);
-	bigint costOfLiteral = gasMeter.costs(
-		Literal{
-			{},
-			LiteralKind::Number,
-			// a dummy 256-bit number to represent the Keccak256 hash.
-			YulString{numeric_limits<u256>::max().str()},
-			{}
-		}
-	);
-
-	// We skip if there are no net gas savings.
-	// Note that for default `m_runs = 200`, the values are
-	// `costOfLiteral = 7200` and `costOfKeccak = 9000` for runtime context.
-	// For creation context: `costOfLiteral = 531` and `costOfKeccak = 90`.
-	if (costOfLiteral > costOfKeccak)
-		return;
-
 	optional<YulString> value = memoryValue(memoryKey->name);
 	if (value && inScope(*value))
 	{

--- a/test/cmdlineTests/keccak_optimization_deploy_code/output
+++ b/test/cmdlineTests/keccak_optimization_deploy_code/output
@@ -6,8 +6,7 @@ object "C_12" {
             /// @src 0:62:463  "contract C {..."
             if callvalue() { revert(0, 0) }
             /// @src 0:103:275  "assembly {..."
-            mstore(0, 100)
-            sstore(0, keccak256(0, 32))
+            sstore(0, 17385872270140913825666367956517731270094621555228275961425792378517567244498)
             /// @src 0:62:463  "contract C {..."
             let _1 := datasize("C_12_deployed")
             codecopy(128, dataoffset("C_12_deployed"), _1)

--- a/test/cmdlineTests/keccak_optimization_low_runs/output
+++ b/test/cmdlineTests/keccak_optimization_low_runs/output
@@ -19,8 +19,7 @@ object "C_7" {
                 /// @src 0:62:285  "contract C {..."
                 if callvalue() { revert(0, 0) }
                 /// @src 0:109:277  "assembly {..."
-                mstore(0, 100)
-                sstore(0, keccak256(0, 32))
+                sstore(0, 17385872270140913825666367956517731270094621555228275961425792378517567244498)
                 /// @src 0:62:285  "contract C {..."
                 stop()
             }


### PR DESCRIPTION
In creation context, LoadResolver prefers call to keccak256 instead of trying to evaluate it. This patch gets the LoadResolver to always evaluate the keccak256.