### PR TITLE
[0.8.8] Implement the workaround for zksolc to lower recursion; Lower indirect calls using selectors

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2
         with:
           repository: matter-labs/compiler-tester
+          ref: az-cpr-532-implement-the-recursion-workaround
           submodules: recursive
           path: compiler-tester
           token: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}
@@ -118,6 +119,7 @@ jobs:
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2
         with:
           repository: matter-labs/compiler-tester
+          ref: main
           submodules: recursive
           path: compiler-tester
           token: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}
@@ -173,6 +175,7 @@ jobs:
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2
         with:
           repository: matter-labs/compiler-tester
+          ref: az-cpr-532-implement-the-recursion-workaround
           submodules: recursive
           path: compiler-tester
           token: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           repository: matter-labs/compiler-tester
           path: compiler-tester
+          ref: az-cpr-532-implement-the-recursion-workaround
           submodules: recursive
           token: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}
 

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -398,7 +398,7 @@ Assembly& Assembly::optimise(bool _enable, EVMVersion _evmVersion, bool _isCreat
 
 Assembly& Assembly::optimise(OptimiserSettings const& _settings)
 {
-	optimiseInternal(_settings, {});
+	(void) _settings;
 	return *this;
 }
 

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -81,6 +81,10 @@ set(sources
 	codegen/ContractCompiler.h
 	codegen/ExpressionCompiler.cpp
 	codegen/ExpressionCompiler.h
+	codegen/ExtraMetadata.cpp
+	codegen/ExtraMetadata.h
+	codegen/FuncPtrTracker.cpp
+	codegen/FuncPtrTracker.h
 	codegen/LValue.cpp
 	codegen/LValue.h
 	codegen/MultiUseYulFunctionCollector.h

--- a/libsolidity/analysis/FunctionCallGraph.cpp
+++ b/libsolidity/analysis/FunctionCallGraph.cpp
@@ -121,10 +121,21 @@ bool FunctionCallGraphBuilder::visit(FunctionCall const& _functionCall)
 	solAssert(functionType, "");
 
 	if (functionType->kind() == FunctionType::Kind::Internal && !_functionCall.expression().annotation().calledDirectly)
+	{
+		for (FunctionDefinition const* funcPtrRef: m_contract.annotation().intFuncPtrRefs)
+		{
+			FunctionType const* funcPtrRefType = funcPtrRef->functionType(/*_internal=*/true);
+			solAssert(funcPtrRefType, "");
+			if (!funcPtrRefType->hasEqualParameterTypes(*functionType)
+				|| !funcPtrRefType->hasEqualReturnTypes(*functionType) || !funcPtrRef->isImplemented())
+				continue;
+			m_graph.indirectEdges[m_currentNode].insert(funcPtrRef);
+		}
 		// If it's not a direct call, we don't really know which function will be called (it may even
 		// change at runtime). All we can do is to add an edge to the dispatch which in turn has
 		// edges to all functions could possibly be called.
 		add(m_currentNode, CallGraph::SpecialNode::InternalDispatch);
+	}
 	else if (functionType->kind() == FunctionType::Kind::Error)
 		m_graph.usedErrors.insert(&dynamic_cast<ErrorDefinition const&>(functionType->declaration()));
 

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -29,6 +29,8 @@
 
 #include <libsolutil/SetOnce.h>
 
+#include <libyul/AST.h>
+
 #include <map>
 #include <memory>
 #include <optional>
@@ -165,6 +167,8 @@ struct ContractDefinitionAnnotation: TypeDeclarationAnnotation, StructurallyDocu
 	SetOnce<std::shared_ptr<CallGraph const>> creationCallGraph;
 	/// A graph with edges representing calls between functions that may happen in a deployed contract.
 	SetOnce<std::shared_ptr<CallGraph const>> deployedCallGraph;
+	/// Set of internal functions referenced as function pointers
+	std::set<FunctionDefinition const*, ASTCompareByID<FunctionDefinition>> intFuncPtrRefs;
 
 	/// List of contracts whose bytecode is referenced by this contract, e.g. through "new".
 	/// The Value represents the ast node that referenced the contract.
@@ -220,6 +224,8 @@ struct InlineAssemblyAnnotation: StatementAnnotation
 	std::map<yul::Identifier const*, ExternalIdentifierInfo> externalReferences;
 	/// Information generated during analysis phase.
 	std::shared_ptr<yul::AsmAnalysisInfo> analysisInfo;
+	/// The yul block of the InlineAssembly::operations() after optimizations.
+	std::shared_ptr<yul::Block> optimizedOperations;
 };
 
 struct BlockAnnotation: StatementAnnotation, ScopableAnnotation

--- a/libsolidity/ast/CallGraph.cpp
+++ b/libsolidity/ast/CallGraph.cpp
@@ -44,3 +44,132 @@ bool CallGraph::CompareByID::operator()(int64_t _lhs, Node const& _rhs) const
 
 	return _lhs < get<CallableDeclaration const*>(_rhs)->id();
 }
+
+/// Populates reachable cycles from m_src into paths;
+class CycleFinder
+{
+	CallGraph const& m_callGraph;
+	CallableDeclaration const* m_src;
+	set<CallableDeclaration const*> m_processing;
+	set<CallableDeclaration const*> m_processed;
+	vector<CallGraph::Path> m_paths;
+
+	/// Populates `m_paths` with cycles reachable from @a _callable
+	void getCyclesInternal(CallableDeclaration const* _callable, CallGraph::Path& _path)
+	{
+		if (m_processed.count(_callable))
+			return;
+
+		auto directCallees = m_callGraph.edges.find(_callable);
+		auto indirectCallees = m_callGraph.indirectEdges.find(_callable);
+		// Is _callable a leaf node?
+		if (directCallees == m_callGraph.edges.end() && indirectCallees == m_callGraph.indirectEdges.end())
+		{
+			solAssert(m_processing.count(_callable) == 0, "");
+			m_processed.insert(_callable);
+			return;
+		}
+
+		m_processing.insert(_callable);
+		_path.push_back(_callable);
+
+		// Traverse all the direct and indirect callees
+		set<CallGraph::Node, CallGraph::CompareByID> callees;
+		if (directCallees != m_callGraph.edges.end())
+			callees.insert(directCallees->second.begin(), directCallees->second.end());
+		if (indirectCallees != m_callGraph.indirectEdges.end())
+			callees.insert(indirectCallees->second.begin(), indirectCallees->second.end());
+		for (auto const& calleeVariant: callees)
+		{
+			if (!holds_alternative<CallableDeclaration const*>(calleeVariant))
+				continue;
+			auto* callee = get<CallableDeclaration const*>(calleeVariant);
+
+			if (m_processing.count(callee))
+			{
+				// Extract the cycle
+				auto cycleStart = std::find(_path.begin(), _path.end(), callee);
+				solAssert(cycleStart != _path.end(), "");
+				m_paths.emplace_back(cycleStart, _path.end());
+				continue;
+			}
+
+			getCyclesInternal(callee, _path);
+		}
+
+		m_processing.erase(_callable);
+		m_processed.insert(_callable);
+		_path.pop_back();
+	}
+
+public:
+	CycleFinder(CallGraph const& _callGraph, CallableDeclaration const* _src): m_callGraph(_callGraph), m_src(_src) {}
+
+	vector<CallGraph::Path> getCycles()
+	{
+		CallGraph::Path p;
+		getCyclesInternal(m_src, p);
+		return m_paths;
+	}
+
+	void dump(ostream& _out)
+	{
+		for (CallGraph::Path const& path: m_paths)
+		{
+			for (CallableDeclaration const* func: path)
+				_out << func->name() << " -> ";
+			_out << "\n";
+		}
+	}
+};
+
+void CallGraph::getReachableFuncs(CallableDeclaration const* _src, std::set<CallableDeclaration const*>& _funcs) const
+{
+	if (_funcs.count(_src))
+		return;
+	_funcs.insert(_src);
+
+	auto directCallees = edges.find(_src);
+	auto indirectCallees = indirectEdges.find(_src);
+	// Is _src a leaf node?
+	if (directCallees == edges.end() && indirectCallees == indirectEdges.end())
+		return;
+
+	// Traverse all the direct and indirect callees
+	set<CallGraph::Node, CallGraph::CompareByID> callees;
+	if (directCallees != edges.end())
+		callees.insert(directCallees->second.begin(), directCallees->second.end());
+	if (indirectCallees != indirectEdges.end())
+		callees.insert(indirectCallees->second.begin(), indirectCallees->second.end());
+
+	for (auto const& calleeVariant: callees)
+	{
+		if (!holds_alternative<CallableDeclaration const*>(calleeVariant))
+			continue;
+		auto* callee = get<CallableDeclaration const*>(calleeVariant);
+		getReachableFuncs(callee, _funcs);
+	}
+}
+
+std::set<CallableDeclaration const*> CallGraph::getReachableFuncs(CallableDeclaration const* _src) const
+{
+	std::set<CallableDeclaration const*> funcs;
+	getReachableFuncs(_src, funcs);
+	return funcs;
+}
+
+std::set<CallableDeclaration const*> CallGraph::getReachableCycleFuncs(CallableDeclaration const* _src) const
+{
+	std::set<CallableDeclaration const*> funcs;
+	CycleFinder cf{*this, _src};
+	vector<CallGraph::Path> paths = cf.getCycles();
+
+	for (CallGraph::Path const& path: paths)
+	{
+		for (CallableDeclaration const* func: path)
+		{
+			funcs.insert(func);
+		}
+	}
+	return funcs;
+}

--- a/libsolidity/ast/CallGraph.h
+++ b/libsolidity/ast/CallGraph.h
@@ -47,6 +47,7 @@ struct CallGraph
 	};
 
 	using Node = std::variant<CallableDeclaration const*, SpecialNode>;
+	using Path = std::vector<CallableDeclaration const*>;
 
 	struct CompareByID
 	{
@@ -61,6 +62,9 @@ struct CallGraph
 	/// any calls.
 	std::map<Node, std::set<Node, CompareByID>, CompareByID> edges;
 
+	/// Graph edges for indirect calls
+	std::map<Node, std::set<Node, CompareByID>, CompareByID> indirectEdges;
+
 	/// Contracts that need to be compiled before this one can be compiled.
 	/// The value is the ast node that created the dependency.
 	std::map<ContractDefinition const*, ASTNode const*, ASTCompareByID<ContractDefinition>> bytecodeDependency;
@@ -70,6 +74,17 @@ struct CallGraph
 
 	/// Errors that are used by functions present in the graph.
 	std::set<ErrorDefinition const*, ASTNode::CompareByID> usedErrors;
+
+	/// Returns functions reachable from @a _src that belong to a cycle. Note that the cycle can be due to indirect
+	/// calls.
+	std::set<CallableDeclaration const*> getReachableCycleFuncs(CallableDeclaration const* _src) const;
+
+	/// Returns functions reachable (including the ones from indirect calls) from @a _src.
+	std::set<CallableDeclaration const*> getReachableFuncs(CallableDeclaration const* _src) const;
+
+private:
+	/// Populates @a _funcs with the functions reachable (including the ones from indirect calls) from @a _src.
+	void getReachableFuncs(CallableDeclaration const* _src, std::set<CallableDeclaration const*>& _funcs) const;
 };
 
 }

--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -309,6 +309,17 @@ void ArrayUtils::copyArrayToStorage(ArrayType const& _targetType, ArrayType cons
 			_context << Instruction::POP;
 		}
 	);
+
+	if (auto* structType = dynamic_cast<StructType const*>(_sourceType.baseType()))
+	{
+		if (structType->recursive())
+		{
+			string name{"$copyArrayToStorage_" + sourceType->identifier() + "_to_" + targetType->identifier()};
+			auto tag = m_context.lowLevelFunctionTagIfExists(name);
+			solAssert(tag != evmasm::AssemblyItem(evmasm::UndefinedItem), "");
+			m_context.addRecursiveLowLevelFunc({name, tag.data().convert_to<uint32_t>(), /*ins=*/3, /*outs=*/1});
+		}
+	}
 }
 
 void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWordBoundaries) const
@@ -611,6 +622,17 @@ void ArrayUtils::clearArray(ArrayType const& _typeIn) const
 			solAssert(_context.stackHeight() == stackHeightStart - 2, "");
 		}
 	);
+
+	if (auto* structType = dynamic_cast<StructType const*>(_typeIn.baseType()))
+	{
+		if (structType->recursive())
+		{
+			string name{"$clearArray_" + _typeIn.identifier()};
+			auto tag = m_context.lowLevelFunctionTagIfExists(name);
+			solAssert(tag != evmasm::AssemblyItem(evmasm::UndefinedItem), "");
+			m_context.addRecursiveLowLevelFunc({name, tag.data().convert_to<uint32_t>(), /*ins=*/2, /*outs=*/0});
+		}
+	}
 }
 
 void ArrayUtils::clearDynamicArray(ArrayType const& _type) const

--- a/libsolidity/codegen/Compiler.cpp
+++ b/libsolidity/codegen/Compiler.cpp
@@ -24,6 +24,8 @@
 #include <libsolidity/codegen/Compiler.h>
 
 #include <libsolidity/codegen/ContractCompiler.h>
+#include <libsolidity/codegen/ExtraMetadata.h>
+
 #include <libevmasm/Assembly.h>
 
 using namespace std;
@@ -50,6 +52,9 @@ void Compiler::compileContract(
 	m_runtimeSub = creationCompiler.compileConstructor(_contract, _otherCompilers);
 
 	m_context.optimise(m_optimiserSettings);
+
+	ExtraMetadataRecorder extraMetadataRecorder{m_context, m_runtimeContext};
+	m_extraMetadata = extraMetadataRecorder.run(_contract);
 
 	solAssert(m_context.appendYulUtilityFunctionsRan(), "appendYulUtilityFunctions() was not called.");
 	solAssert(m_runtimeContext.appendYulUtilityFunctionsRan(), "appendYulUtilityFunctions() was not called.");

--- a/libsolidity/codegen/Compiler.h
+++ b/libsolidity/codegen/Compiler.h
@@ -61,8 +61,10 @@ public:
 
 	std::string generatedYulUtilityCode() const { return m_context.generatedYulUtilityCode(); }
 	std::string runtimeGeneratedYulUtilityCode() const { return m_runtimeContext.generatedYulUtilityCode(); }
+	Json::Value extraMetadata() const { return m_extraMetadata; }
 
 private:
+	Json::Value m_extraMetadata;
 	OptimiserSettings const m_optimiserSettings;
 	CompilerContext m_runtimeContext;
 	size_t m_runtimeSub = size_t(-1); ///< Identifier of the runtime sub-assembly, if present.

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -169,6 +169,15 @@ evmasm::AssemblyItem CompilerContext::lowLevelFunctionTag(
 		return it->second;
 }
 
+evmasm::AssemblyItem CompilerContext::lowLevelFunctionTagIfExists(string const& _name)
+{
+	auto it = m_lowLevelFunctions.find(_name);
+	if (it == m_lowLevelFunctions.end())
+		return evmasm::AssemblyItem(evmasm::UndefinedItem);
+	else
+		return it->second;
+}
+
 void CompilerContext::appendMissingLowLevelFunctions()
 {
 	while (!m_lowLevelFunctionGenerationQueue.empty())
@@ -516,11 +525,13 @@ void CompilerContext::appendInlineAssembly(
 		reportError("Failed to analyze inline assembly block.");
 
 	solAssert(errorReporter.errors().empty(), "Failed to analyze inline assembly block.");
+	shared_ptr<yul::CodeTransformContext> yulContext;
 	yul::CodeGenerator::assemble(
 		*parserResult,
 		analysisInfo,
 		*m_asm,
 		m_evmVersion,
+		yulContext,
 		identifierAccess.generateCode,
 		_system,
 		_optimiserSettings.optimizeStackAllocation

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -40,6 +40,7 @@
 
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/backends/evm/EVMDialect.h>
+#include <libyul/backends/evm/EVMCodeTransform.h>
 
 #include <functional>
 #include <ostream>
@@ -163,6 +164,10 @@ public:
 		unsigned _outArgs,
 		std::function<void(CompilerContext&)> const& _generator
 	);
+	/// Returns the entry tag of the low-level function with the name @a _name if already generated; Returns
+	/// evmasm::AssemblyItem(evmasm::UndefinedItem) if the entry tag is not generated.
+	evmasm::AssemblyItem lowLevelFunctionTagIfExists(std::string const& _name);
+
 	/// Generates the code for missing low-level functions, i.e. calls the generators passed above.
 	void appendMissingLowLevelFunctions();
 	ABIFunctions& abiFunctions() { return m_abiFunctions; }
@@ -296,6 +301,40 @@ public:
 	/// Should be avoided except when adding sub-assemblies.
 	std::shared_ptr<evmasm::Assembly> assemblyPtr() const { return m_asm; }
 
+	/// Adds the @a _asm -> @a _context mapping in the internal inline assembly to context mapping
+	void addInlineAsmContextMapping(InlineAssembly const* _asm, std::shared_ptr<yul::CodeTransformContext> _context)
+	{
+		m_inlineAsmContextMap[_asm] = _context;
+	}
+
+	/// Returns the context for @a _asm; nullptr if not found
+	yul::CodeTransformContext const* findInlineAsmContextMapping(InlineAssembly const* _asm) const
+	{
+		auto findIt = m_inlineAsmContextMap.find(_asm);
+		if (findIt == m_inlineAsmContextMap.end())
+			return nullptr;
+		return findIt->second.get();
+	}
+
+	struct FunctionInfo
+	{
+		std::string const name;
+		unsigned tag;
+		unsigned ins;
+		unsigned outs;
+
+		bool operator<(FunctionInfo const& _other) const
+		{
+			return tie(name, tag, ins, outs) < tie(_other.name, _other.tag, _other.ins, _other.outs);
+		}
+	};
+
+	/// Adds @a _func to the set of low level utility functions that are recursive
+	void addRecursiveLowLevelFunc(FunctionInfo _func) { m_recursiveLowLevelFuncs.insert(_func); }
+
+	/// Returns the set of low level utility functions that are recursive
+	std::set<FunctionInfo> const& recursiveLowLevelFuncs() const { return m_recursiveLowLevelFuncs; }
+
 	/**
 	 * Helper class to pop the visited nodes stack when a scope closes
 	 */
@@ -400,6 +439,10 @@ private:
 	std::queue<std::tuple<std::string, unsigned, unsigned, std::function<void(CompilerContext&)>>> m_lowLevelFunctionGenerationQueue;
 	/// Flag to check that appendYulUtilityFunctions() was called exactly once
 	bool m_appendYulUtilityFunctionsRan = false;
+	/// Maps an InlineAssembly AST node to its CodeTransformContext created during its lowering
+	std::map<InlineAssembly const*, std::shared_ptr<yul::CodeTransformContext>> m_inlineAsmContextMap;
+	/// Set of low level utility functions generated in this context that are recursive
+	std::set<FunctionInfo> m_recursiveLowLevelFuncs;
 };
 
 }

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1195,12 +1195,21 @@ void CompilerUtils::convertType(
 					_context << Instruction::POP << Instruction::POP;
 				};
 				if (typeOnStack.recursive())
+				{
 					m_context.callLowLevelFunction(
 						"$convertRecursiveArrayStorageToMemory_" + typeOnStack.identifier() + "_to_" + targetType.identifier(),
 						1,
 						1,
 						conversionImpl
 					);
+					string name{
+						"$convertRecursiveArrayStorageToMemory_" + typeOnStack.identifier() + "_to_"
+						+ targetType.identifier()};
+					auto tag = m_context.lowLevelFunctionTagIfExists(name);
+					solAssert(tag != evmasm::AssemblyItem(evmasm::UndefinedItem), "");
+					m_context.addRecursiveLowLevelFunc(
+						{name, tag.data().convert_to<uint32_t>(), /*ins=*/1, /*outs=*/1});
+				}
 				else
 					conversionImpl(m_context);
 				break;

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -35,6 +35,7 @@
 #include <libyul/backends/evm/AsmCodeGen.h>
 #include <libyul/backends/evm/EVMMetrics.h>
 #include <libyul/backends/evm/EVMDialect.h>
+#include <libyul/optimiser/Disambiguator.h>
 #include <libyul/optimiser/Suite.h>
 #include <libyul/Object.h>
 #include <libyul/optimiser/ASTCopier.h>
@@ -711,6 +712,20 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 	{
 		solAssert(_context == yul::IdentifierContext::RValue || _context == yul::IdentifierContext::LValue, "");
 		auto ref = _inlineAssembly.annotation().externalReferences.find(&_identifier);
+		if (ref == _inlineAssembly.annotation().externalReferences.end())
+		{
+			// The yul AST might be copied from the original (In case we ran the Disambiguator, for instance). So we'll
+			// search for the identifier's name instead.
+			auto& externalReferences = _inlineAssembly.annotation().externalReferences;
+			for (auto extRef = externalReferences.begin(); extRef != externalReferences.end(); ++extRef)
+			{
+				if (extRef->first->name == _identifier.name)
+				{
+					ref = extRef;
+					break;
+				}
+			}
+		}
 		solAssert(ref != _inlineAssembly.annotation().externalReferences.end(), "");
 		Declaration const* decl = ref->second.declaration;
 		solAssert(!!decl, "");
@@ -921,18 +936,55 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 		m_context.optimizeYul(object, *dialect, m_optimiserSettings);
 
 		code = object.code.get();
+		_inlineAssembly.annotation().optimizedOperations = object.code;
+		analysisInfo = object.analysisInfo.get();
+	}
+	else
+	{
+		auto const* dialect = dynamic_cast<yul::EVMDialect const*>(&_inlineAssembly.dialect());
+		solAssert(dialect, "");
+
+		// Run the disambiguator.
+		// We need this so that the yul::CallGraphGenerator runs correctly (which is required for setting the
+		// "recursiveFunctions" record in the extraMetadata for inline assembly)
+		set<yul::YulString> reservedIdentifiers = dialect->fixedFunctionNames();
+		for (auto extRef: _inlineAssembly.annotation().externalReferences)
+		{
+			reservedIdentifiers.insert(extRef.first->name);
+		}
+		yul::Disambiguator disambiguator(*dialect, *analysisInfo, reservedIdentifiers);
+		object.code = make_shared<yul::Block>(get<yul::Block>(disambiguator(*code)));
+
+		// Run the AsmAnalyzer on `object.code`.
+		// Create a resolver that accepts any identifiers. This is OK since the TypeChecker already did the resolution
+		// and the disambiguator should have left them as it is.
+		yul::ExternalIdentifierAccess::Resolver resolver
+			= [](yul::Identifier const& _identifier, yul::IdentifierContext _context, bool) -> bool
+		{
+			(void) _identifier;
+			(void) _context;
+			return true;
+		};
+		object.analysisInfo = make_shared<yul::AsmAnalysisInfo>(
+			yul::AsmAnalyzer::analyzeStrictAssertCorrect(*dialect, object, resolver));
+
+		code = object.code.get();
+		_inlineAssembly.annotation().optimizedOperations = object.code;
 		analysisInfo = object.analysisInfo.get();
 	}
 
+	shared_ptr<yul::CodeTransformContext> yulContext;
 	yul::CodeGenerator::assemble(
 		*code,
 		*analysisInfo,
 		*m_context.assemblyPtr(),
 		m_context.evmVersion(),
+		yulContext,
 		identifierAccessCodeGen,
 		false,
 		m_optimiserSettings.optimizeStackAllocation
 	);
+	m_context.addInlineAsmContextMapping(&_inlineAssembly, yulContext);
 	m_context.setStackOffset(static_cast<int>(startStackHeight));
 	return false;
 }

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -551,6 +551,68 @@ bool ExpressionCompiler::visit(BinaryOperation const& _binaryOperation)
 	return false;
 }
 
+void ExpressionCompiler::generateSelector(FunctionType const& _funcType)
+{
+	// Are we in the creation context?
+	if (m_context.runtimeContext())
+	{
+		// Extract only the low 32 bits for matching in the tag selector
+		m_context << u256(0xffffffff) << Instruction::AND;
+	}
+
+	struct TagInfo
+	{
+		evmasm::AssemblyItem const tag;
+		FunctionDefinition const* func;
+	};
+	vector<TagInfo> tagInfos;
+
+	for (auto* intFuncPtrRef: m_context.mostDerivedContract().annotation().intFuncPtrRefs)
+	{
+		FunctionType const* intFuncPtrRefType = intFuncPtrRef->functionType(true);
+		// ContractDefinitionAnnotation::intFuncPtrRefs should only contain refs to internal functions
+		solAssert(intFuncPtrRefType, "");
+		if (!intFuncPtrRefType->hasEqualParameterTypes(_funcType) || !intFuncPtrRefType->hasEqualReturnTypes(_funcType)
+			|| !intFuncPtrRef->isImplemented())
+			continue;
+
+		// The loaded function pointer
+		m_context << Instruction::DUP1;
+		// We don't need to resolve the function here since FuncPtrTracker already did that.
+		m_context << m_context.functionEntryLabel(*intFuncPtrRef).pushTag();
+		m_context << Instruction::EQ;
+
+		evmasm::AssemblyItem newTag = m_context.newTag();
+		m_context.appendConditionalJumpTo(newTag);
+		tagInfos.push_back({newTag, intFuncPtrRef});
+	}
+
+	if (tagInfos.empty())
+	{
+		// Pop the original function pointer
+		m_context << Instruction::POP;
+	}
+	// If we can't match the entry tag of any of the internal function
+	m_context.appendPanic(PanicCode::InvalidInternalFunction);
+
+	unsigned int stkOffsetAfterJumpI = m_context.stackHeight();
+	for (TagInfo& tagInfo: tagInfos)
+	{
+		// The PC is set to this tag from the jumpi, so we need to set the stack offset correctly
+		m_context.setStackOffset((int) stkOffsetAfterJumpI);
+
+		m_context << tagInfo.tag;
+
+		// Pop the original function pointer
+		m_context << Instruction::POP;
+
+		// We don't need to resolve the function here since FuncPtrTracker already did that.
+		m_context << m_context.functionEntryLabel(*tagInfo.func).pushTag();
+		m_context.appendJump(evmasm::AssemblyItem::JumpType::IntoFunction);
+		// After the call, the vm's pc should be set to the return label since it is pushed to the stack.
+	}
+}
+
 bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 {
 	auto functionCallKind = *_functionCall.annotation().kind;
@@ -664,6 +726,13 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				parameterSize += function.selfType()->sizeOnStack();
 			}
 
+			// There can be cases when ExpressionAnnotation::calledDirectly is false but we can infer that it is a
+			// direct call if the target PC is a literal tag
+			bool directCallInferred = false;
+			auto const& currAsmItems = m_context.assembly().items();
+			if (!currAsmItems.empty() && currAsmItems.back().type() == AssemblyItemType::PushTag)
+				directCallInferred = true;
+
 			if (m_context.runtimeContext())
 				// We have a runtime context, so we need the creation part.
 				utils().rightShiftNumberOnStack(32);
@@ -671,7 +740,12 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				// Extract the runtime part.
 				m_context << ((u256(1) << 32) - 1) << Instruction::AND;
 
-			m_context.appendJump(evmasm::AssemblyItem::JumpType::IntoFunction);
+			// Is this a direct call?
+			if (_functionCall.expression().annotation().calledDirectly || directCallInferred)
+				m_context.appendJump(evmasm::AssemblyItem::JumpType::IntoFunction);
+			else
+				generateSelector(function);
+
 			m_context << returnLabel;
 
 			unsigned returnParametersSize = CompilerUtils::sizeOnStack(function.returnParameterTypes());

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -139,6 +139,9 @@ private:
 	/// @returns the CompilerUtils object containing the current context.
 	CompilerUtils utils();
 
+	/// Generates the selector for internal function pointer with type @a _funcType.
+	void generateSelector(FunctionType const& _funcType);
+
 	bool m_optimiseOrderLiterals;
 	CompilerContext& m_context;
 	std::unique_ptr<LValue> m_currentLValue;

--- a/libsolidity/codegen/ExtraMetadata.cpp
+++ b/libsolidity/codegen/ExtraMetadata.cpp
@@ -1,0 +1,182 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/codegen/ExtraMetadata.h>
+
+#include <libsolidity/ast/CallGraph.h>
+#include <libsolidity/codegen/FuncPtrTracker.h>
+
+#include <libyul/optimiser/CallGraphGenerator.h>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::frontend;
+
+class InlineAsmRecursiveFuncRecorder: public ASTConstVisitor
+{
+public:
+	void run() { m_func.accept(*this); }
+
+	InlineAsmRecursiveFuncRecorder(
+		CallableDeclaration const& _func,
+		CompilerContext const& _context,
+		CompilerContext const& _runtimeContext,
+		Json::Value& _recFuncs)
+		: m_func(_func), m_context(_context), m_runtimeContext(_runtimeContext), m_recFuncs(_recFuncs)
+	{
+	}
+
+private:
+	CallableDeclaration const& m_func;
+	CompilerContext const& m_context;
+	CompilerContext const& m_runtimeContext;
+	Json::Value& m_recFuncs;
+
+	// Record recursions in @_asm for the extra metadata
+	void record(InlineAssembly const& _asm, CompilerContext const& _context)
+	{
+		auto findRes = _context.findInlineAsmContextMapping(&_asm);
+		if (!findRes)
+			return;
+		yul::CodeTransformContext const& yulContext = *findRes;
+
+		set<yul::YulString> recFuncs;
+		if (_asm.annotation().optimizedOperations)
+		{
+			yul::Block const& code = *_asm.annotation().optimizedOperations;
+			recFuncs = yul::CallGraphGenerator::callGraph(code).recursiveFunctions();
+		}
+		else
+		{
+			recFuncs = yul::CallGraphGenerator::callGraph(_asm.operations()).recursiveFunctions();
+		}
+		for (auto recFunc: recFuncs)
+		{
+			auto findIt = yulContext.functionInfoMap.find(recFunc);
+			if (findIt == yulContext.functionInfoMap.end())
+				continue;
+			for (auto& func: findIt->second)
+			{
+				Json::Value record(Json::objectValue);
+				record["name"] = recFunc.str();
+				if (_context.runtimeContext())
+					record["creationTag"] = func.label;
+				else
+					record["runtimeTag"] = func.label;
+				record["totalParamSize"] = func.ast->parameters.size();
+				record["totalRetParamSize"] = func.ast->returnVariables.size();
+				m_recFuncs.append(record);
+			}
+		}
+	}
+
+	void endVisit(InlineAssembly const& _asm)
+	{
+		record(_asm, m_context);
+		record(_asm, m_runtimeContext);
+	}
+};
+
+Json::Value ExtraMetadataRecorder::run(ContractDefinition const& _contract)
+{
+	// Set "recursiveFunctions"
+	Json::Value recFuncs(Json::arrayValue);
+
+	// Record recursions in low level calls
+	auto recordRecursiveLowLevelFuncs = [&](CompilerContext const& _context)
+	{
+		for (auto fn: _context.recursiveLowLevelFuncs())
+		{
+			Json::Value func(Json::objectValue);
+			func["name"] = fn.name;
+			if (_context.runtimeContext())
+				func["creationTag"] = fn.tag;
+			else
+				func["runtimeTag"] = fn.tag;
+			func["totalParamSize"] = fn.ins;
+			func["totalRetParamSize"] = fn.outs;
+			recFuncs.append(func);
+		}
+	};
+	recordRecursiveLowLevelFuncs(m_context);
+	recordRecursiveLowLevelFuncs(m_runtimeContext);
+
+	// Get reachable functions from the call-graphs; And get cycles in the call-graphs
+	auto& creationCallGraph = _contract.annotation().creationCallGraph;
+	auto& runtimeCallGraph = _contract.annotation().deployedCallGraph;
+
+	set<CallableDeclaration const*> reachableCycleFuncs, reachableFuncs;
+
+	for (FunctionDefinition const* fn: _contract.definedFunctions())
+	{
+		if (fn->isConstructor() && creationCallGraph.set())
+		{
+			reachableCycleFuncs += (*creationCallGraph)->getReachableCycleFuncs(fn);
+			reachableFuncs += (*creationCallGraph)->getReachableFuncs(fn);
+		}
+		else if (runtimeCallGraph.set())
+		{
+			reachableCycleFuncs += (*runtimeCallGraph)->getReachableCycleFuncs(fn);
+			reachableFuncs += (*runtimeCallGraph)->getReachableFuncs(fn);
+		}
+	}
+
+	// Record recursions in inline assembly
+	for (auto* fn: reachableFuncs)
+	{
+		InlineAsmRecursiveFuncRecorder inAsmRecorder{*fn, m_context, m_runtimeContext, recFuncs};
+		inAsmRecorder.run();
+	}
+
+	// Record recursions in the solidity source
+	auto recordRecursiveSolFuncs = [&](CompilerContext const& _context)
+	{
+		for (auto* fn: reachableCycleFuncs)
+		{
+			evmasm::AssemblyItem const& tag = _context.functionEntryLabelIfExists(*fn);
+			if (tag == evmasm::AssemblyItem(evmasm::UndefinedItem))
+				continue;
+
+			Json::Value func(Json::objectValue);
+			func["name"] = fn->name();
+
+			// Assembly::new[Push]Tag() asserts that the tag is 32 bits
+			auto tagNum = tag.data().convert_to<uint32_t>();
+			if (_context.runtimeContext())
+				func["creationTag"] = tagNum;
+			else
+				func["runtimeTag"] = tagNum;
+
+			unsigned totalParamSize = 0, totalRetParamSize = 0;
+			for (auto& param: fn->parameters())
+				totalParamSize += param->type()->sizeOnStack();
+			func["totalParamSize"] = totalParamSize;
+			for (auto& param: fn->returnParameters())
+				totalRetParamSize += param->type()->sizeOnStack();
+			func["totalRetParamSize"] = totalRetParamSize;
+
+			recFuncs.append(func);
+		}
+	};
+	recordRecursiveSolFuncs(m_context);
+	recordRecursiveSolFuncs(m_runtimeContext);
+
+	if (!recFuncs.empty())
+		m_metadata["recursiveFunctions"] = recFuncs;
+	return m_metadata;
+}

--- a/libsolidity/codegen/ExtraMetadata.h
+++ b/libsolidity/codegen/ExtraMetadata.h
@@ -1,0 +1,53 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * The extra metadata recorder
+ */
+
+#include <libsolidity/ast/ASTForward.h>
+#include <libsolidity/codegen/CompilerContext.h>
+
+#include <json/value.h>
+
+#include <memory>
+
+#pragma once
+
+namespace solidity::frontend
+{
+
+class ExtraMetadataRecorder
+{
+	CompilerContext const& m_context;
+	CompilerContext const& m_runtimeContext;
+	/// The root JSON value of the metadata
+	/// Current mappings:
+	/// - "recursiveFunctions": array of functions involved in recursion
+	Json::Value m_metadata;
+
+public:
+	ExtraMetadataRecorder(CompilerContext const& _context, CompilerContext const& _runtimeContext)
+		: m_context(_context), m_runtimeContext(_runtimeContext)
+	{
+	}
+
+	/// Stores the extra metadata of @a _contract in `metadata`
+	Json::Value run(ContractDefinition const& _contract);
+};
+
+}

--- a/libsolidity/codegen/FuncPtrTracker.cpp
+++ b/libsolidity/codegen/FuncPtrTracker.cpp
@@ -1,0 +1,108 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/codegen/FuncPtrTracker.h>
+
+#include <liblangutil/Exceptions.h>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::frontend;
+
+void FuncPtrTracker::endVisit(Identifier const& _identifier)
+{
+	Declaration const* declaration = _identifier.annotation().referencedDeclaration;
+	FunctionDefinition const* functionDef = dynamic_cast<FunctionDefinition const*>(declaration);
+	if (!functionDef)
+		return;
+
+	solAssert(*_identifier.annotation().requiredLookup == VirtualLookup::Virtual, "");
+	FunctionDefinition const& resolvedFunctionDef = functionDef->resolveVirtual(m_contract);
+
+	solAssert(resolvedFunctionDef.functionType(true), "");
+	solAssert(resolvedFunctionDef.functionType(true)->kind() == FunctionType::Kind::Internal, "");
+	if (_identifier.annotation().calledDirectly)
+		return;
+	m_contract.annotation().intFuncPtrRefs.insert(&resolvedFunctionDef);
+}
+
+void FuncPtrTracker::endVisit(MemberAccess const& _memberAccess)
+{
+	auto memberFunctionType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type);
+
+	if (memberFunctionType && memberFunctionType->bound())
+	{
+		solAssert(*_memberAccess.annotation().requiredLookup == VirtualLookup::Static, "");
+		if (memberFunctionType->kind() == FunctionType::Kind::Internal)
+			m_contract.annotation().intFuncPtrRefs.insert(
+				&dynamic_cast<FunctionDefinition const&>(memberFunctionType->declaration()));
+	}
+
+	Type::Category objectCategory = _memberAccess.expression().annotation().type->category();
+	switch (objectCategory)
+	{
+	case Type::Category::TypeType:
+	{
+		Type const& actualType
+			= *dynamic_cast<TypeType const&>(*_memberAccess.expression().annotation().type).actualType();
+
+		if (actualType.category() == Type::Category::Contract)
+		{
+			ContractType const& contractType = dynamic_cast<ContractType const&>(actualType);
+			if (contractType.isSuper())
+			{
+				solAssert(!!_memberAccess.annotation().referencedDeclaration, "Referenced declaration not resolved.");
+				ContractDefinition const* super = contractType.contractDefinition().superContract(m_contract);
+				solAssert(super, "Super contract not available.");
+				FunctionDefinition const& resolvedFunctionDef
+					= dynamic_cast<FunctionDefinition const&>(*_memberAccess.annotation().referencedDeclaration)
+						  .resolveVirtual(m_contract, super);
+
+				solAssert(resolvedFunctionDef.functionType(true), "");
+				solAssert(resolvedFunctionDef.functionType(true)->kind() == FunctionType::Kind::Internal, "");
+				m_contract.annotation().intFuncPtrRefs.insert(&resolvedFunctionDef);
+			}
+			else if (memberFunctionType && memberFunctionType->kind() == FunctionType::Kind::Internal)
+			{
+				if (auto const* function
+					= dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration))
+					m_contract.annotation().intFuncPtrRefs.insert(function);
+			}
+		}
+		break;
+	}
+	case Type::Category::Module:
+	{
+		if (auto const* function
+			= dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration))
+		{
+			auto funType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type);
+			solAssert(function && function->isFree(), "");
+			solAssert(function->functionType(true), "");
+			solAssert(function->functionType(true)->kind() == FunctionType::Kind::Internal, "");
+			solAssert(funType->kind() == FunctionType::Kind::Internal, "");
+			solAssert(*_memberAccess.annotation().requiredLookup == VirtualLookup::Static, "");
+
+			m_contract.annotation().intFuncPtrRefs.insert(function);
+		}
+		break;
+	}
+	default:
+		break;
+	}
+}

--- a/libsolidity/codegen/FuncPtrTracker.h
+++ b/libsolidity/codegen/FuncPtrTracker.h
@@ -1,0 +1,55 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Tracks function pointer references
+ */
+
+#pragma once
+
+#include <libsolidity/ast/ASTVisitor.h>
+#include <libsolidity/codegen/CompilerContext.h>
+
+namespace solidity::frontend
+{
+
+/**
+ * This class is used to add all the function pointer references in the contract and its ancestor contracts to the
+ * ContractDefinitionAnnotation::intFuncPtrRefs.  The visitor is copied from the yul codegen pipeline's usage of
+ * IRGeneratorForStatements::assignInternalFunctionIDIfNotCalledDirectly()
+ */
+class FuncPtrTracker: private ASTConstVisitor
+{
+public:
+	FuncPtrTracker(ContractDefinition const& _contract): m_contract(_contract) {}
+
+	void run()
+	{
+		for (ContractDefinition const* base: m_contract.annotation().linearizedBaseContracts)
+		{
+			base->accept(*this);
+		}
+	}
+
+private:
+	ContractDefinition const& m_contract;
+
+	void endVisit(Identifier const& _identifier);
+	void endVisit(MemberAccess const& _memberAccess);
+};
+
+}

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -48,6 +48,7 @@
 #include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/ast/ASTJsonImporter.h>
 #include <libsolidity/codegen/Compiler.h>
+#include <libsolidity/codegen/FuncPtrTracker.h>
 #include <libsolidity/formal/ModelChecker.h>
 #include <libsolidity/interface/ABI.h>
 #include <libsolidity/interface/Natspec.h>
@@ -108,6 +109,21 @@ CompilerStack::~CompilerStack()
 {
 	--g_compilerStackCounts;
 	TypeProvider::reset();
+}
+
+void CompilerStack::populateFuncPtrRefs()
+{
+	for (Source const* source: m_sourceOrder)
+	{
+		if (!source->ast)
+			continue;
+
+		for (ContractDefinition const* contract: ASTNode::filteredNodes<ContractDefinition>(source->ast->nodes()))
+		{
+			FuncPtrTracker tracker{*contract};
+			tracker.run();
+		}
+	}
 }
 
 void CompilerStack::createAndAssignCallGraphs()
@@ -486,6 +502,7 @@ bool CompilerStack::analyze()
 		// Create & assign callgraphs and check for contract dependency cycles
 		if (noErrors)
 		{
+			populateFuncPtrRefs();
 			createAndAssignCallGraphs();
 			findAndReportCyclicContractDependencies();
 		}
@@ -1020,6 +1037,17 @@ string const& CompilerStack::metadata(Contract const& _contract) const
 	return _contract.metadata.init([&]{ return createMetadata(_contract, m_viaIR); });
 }
 
+Json::Value const& CompilerStack::extraMetadata(string const& _contractName) const
+{
+	Contract const& contr = contract(_contractName);
+	if (m_stackState < AnalysisPerformed)
+		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+
+	solAssert(contr.contract, "");
+
+	return contr.extraMetadata;
+}
+
 CharStream const& CompilerStack::charStream(string const& _sourceName) const
 {
 	if (m_stackState < SourcesSet)
@@ -1285,6 +1313,7 @@ void CompilerStack::compileContract(
 		solAssert(false, "Optimizer exception during compilation");
 	}
 
+	compiledContract.extraMetadata = compiler->extraMetadata();
 	_otherCompilers[compiledContract.contract] = compiler;
 
 	assemble(_contract, compiler->assemblyPtr(), compiler->runtimeAssemblyPtr());

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -329,6 +329,9 @@ public:
 	/// @returns the Contract Metadata matching the pipeline selected using the viaIR setting.
 	std::string const& metadata(std::string const& _contractName) const { return metadata(contract(_contractName)); }
 
+	/// @returns the contract metadata containing miscellaneous information
+	Json::Value const& extraMetadata(std::string const& _contractName) const;
+
 	/// @returns the CBOR-encoded metadata matching the pipeline selected using the viaIR setting.
 	bytes cborMetadata(std::string const& _contractName) const { return cborMetadata(_contractName, m_viaIR); }
 
@@ -373,6 +376,7 @@ private:
 		std::string yulIROptimized; ///< Optimized experimental Yul IR code.
 		std::string ewasm; ///< Experimental Ewasm text representation
 		evmasm::LinkerObject ewasmObject; ///< Experimental Ewasm code
+		Json::Value extraMetadata; ///< Misc metadata
 		util::LazyInit<std::string const> metadata; ///< The metadata json that will be hashed into the chain.
 		util::LazyInit<Json::Value const> abi;
 		util::LazyInit<Json::Value const> storageLayout;
@@ -383,6 +387,9 @@ private:
 		mutable std::optional<std::string const> sourceMapping;
 		mutable std::optional<std::string const> runtimeSourceMapping;
 	};
+
+	/// Populates the function pointer references in the AST annotation of each contract
+	void populateFuncPtrRefs();
 
 	void createAndAssignCallGraphs();
 	void findAndReportCyclicContractDependencies();

--- a/libsolidity/interface/OptimiserSettings.h
+++ b/libsolidity/interface/OptimiserSettings.h
@@ -68,7 +68,6 @@ struct OptimiserSettings
 	static OptimiserSettings minimal()
 	{
 		OptimiserSettings s = none();
-		s.runJumpdestRemover = true;
 		s.runPeephole = true;
 		return s;
 	}
@@ -77,10 +76,7 @@ struct OptimiserSettings
 	{
 		OptimiserSettings s;
 		s.runOrderLiterals = true;
-		s.runInliner = true;
-		s.runJumpdestRemover = true;
 		s.runPeephole = true;
-		s.runDeduplicate = true;
 		s.runCSE = true;
 		s.runConstantOptimiser = true;
 		s.runYulOptimiser = true;

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -1250,6 +1250,10 @@ Json::Value StandardCompiler::compileSolidity(StandardCompiler::InputsAndSetting
 		if (compilationSuccess && isArtifactRequested(_inputsAndSettings.outputSelection, file, name, "evm.gasEstimates", wildcardMatchesExperimental))
 			evmData["gasEstimates"] = compilerStack.gasEstimates(contractName);
 
+		Json::Value extraMetadata = compilerStack.extraMetadata(contractName);
+		if (compilationSuccess && !extraMetadata.empty())
+			evmData["extraMetadata"] = extraMetadata;
+
 		if (compilationSuccess && isArtifactRequested(
 			_inputsAndSettings.outputSelection,
 			file,

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -94,6 +94,18 @@ AsmAnalysisInfo AsmAnalyzer::analyzeStrictAssertCorrect(Dialect const& _dialect,
 	return analysisInfo;
 }
 
+AsmAnalysisInfo AsmAnalyzer::analyzeStrictAssertCorrect(
+	Dialect const& _dialect, Object const& _object, yul::ExternalIdentifierAccess::Resolver _resolver)
+{
+	ErrorList errorList;
+	langutil::ErrorReporter errors(errorList);
+	AsmAnalysisInfo analysisInfo;
+	bool success = yul::AsmAnalyzer(analysisInfo, errors, _dialect, _resolver, _object.qualifiedDataNames())
+					   .analyze(*_object.code);
+	yulAssert(success && !errors.hasErrors(), "Invalid assembly/yul code.");
+	return analysisInfo;
+}
+
 vector<YulString> AsmAnalyzer::operator()(Literal const& _literal)
 {
 	expectValidType(_literal.type, nativeLocationOf(_literal));

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -78,6 +78,8 @@ public:
 	/// Performs analysis on the outermost code of the given object and returns the analysis info.
 	/// Asserts on failure.
 	static AsmAnalysisInfo analyzeStrictAssertCorrect(Dialect const& _dialect, Object const& _object);
+	static AsmAnalysisInfo analyzeStrictAssertCorrect(
+		Dialect const& _dialect, Object const& _object, yul::ExternalIdentifierAccess::Resolver _resolver);
 
 	std::vector<YulString> operator()(Literal const& _literal);
 	std::vector<YulString> operator()(Identifier const&);

--- a/libyul/backends/evm/AsmCodeGen.cpp
+++ b/libyul/backends/evm/AsmCodeGen.cpp
@@ -37,6 +37,7 @@ void CodeGenerator::assemble(
 	AsmAnalysisInfo& _analysisInfo,
 	evmasm::Assembly& _assembly,
 	langutil::EVMVersion _evmVersion,
+	shared_ptr<CodeTransformContext>& _context, // out
 	ExternalIdentifierAccess::CodeGenerator _identifierAccessCodeGen,
 	bool _useNamedLabelsForFunctions,
 	bool _optimizeStackAllocation
@@ -55,6 +56,7 @@ void CodeGenerator::assemble(
 		_useNamedLabelsForFunctions
 	);
 	transform(_parsedData);
+	_context = transform.context();
 	if (!transform.stackErrors().empty())
 		assertThrow(
 			false,

--- a/libyul/backends/evm/AsmCodeGen.h
+++ b/libyul/backends/evm/AsmCodeGen.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <libyul/backends/evm/AbstractAssembly.h>
+#include <libyul/backends/evm/EVMCodeTransform.h>
 #include <libyul/AsmAnalysis.h>
 #include <liblangutil/EVMVersion.h>
 
@@ -44,6 +45,7 @@ public:
 		AsmAnalysisInfo& _analysisInfo,
 		evmasm::Assembly& _assembly,
 		langutil::EVMVersion _evmVersion,
+		std::shared_ptr<CodeTransformContext>& _context, // out
 		ExternalIdentifierAccess::CodeGenerator _identifierAccess = {},
 		bool _useNamedLabelsForFunctions = false,
 		bool _optimizeStackAllocation = false

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -594,6 +594,9 @@ void CodeTransform::createFunctionEntryID(FunctionDefinition const& _function)
 			astID
 		) :
 		m_assembly.newLabelId();
+
+	m_context->functionInfoMap[_function.name].emplace(
+		CodeTransformContext::FunctionInfo{&_function, m_context->functionEntryIDs[&scopeFunction]});
 }
 
 AbstractAssembly::LabelID CodeTransform::functionEntryID(Scope::Function const& _scopeFunction) const

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -42,7 +42,18 @@ struct AsmAnalysisInfo;
 
 struct CodeTransformContext
 {
+	struct FunctionInfo
+	{
+		FunctionDefinition const* ast;
+		AbstractAssembly::LabelID label;
+		bool operator<(FunctionInfo const& _other) const
+		{
+			return std::less<FunctionDefinition const*>{}(ast, _other.ast);
+		}
+	};
+
 	std::map<Scope::Function const*, AbstractAssembly::LabelID> functionEntryIDs;
+	std::map<YulString, std::set<FunctionInfo>> functionInfoMap;
 	std::map<Scope::Variable const*, size_t> variableStackHeights;
 	std::map<Scope::Variable const*, unsigned> variableReferences;
 
@@ -139,6 +150,7 @@ public:
 	void operator()(Continue const&);
 	void operator()(Leave const&);
 	void operator()(Block const& _block);
+	std::shared_ptr<Context> context() { return m_context; }
 
 private:
 	AbstractAssembly::LabelID labelFromIdentifier(Identifier const& _identifier);


### PR DESCRIPTION
- Implement the workaround for zksolc to lower recursion; Lower indirect calls using selectors
- Change the compiler tester branch
