### PR TITLE
[0.6.4] Implement the workaround for zksolc to lower recursion; Lower indirect calls using selectors

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2
         with:
           repository: matter-labs/compiler-tester
+          ref: az-cpr-532-implement-the-recursion-workaround
           submodules: recursive
           path: compiler-tester
           token: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}
@@ -118,6 +119,7 @@ jobs:
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2
         with:
           repository: matter-labs/compiler-tester
+          ref: main
           submodules: recursive
           path: compiler-tester
           token: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}
@@ -173,6 +175,7 @@ jobs:
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2
         with:
           repository: matter-labs/compiler-tester
+          ref: az-cpr-532-implement-the-recursion-workaround
           submodules: recursive
           path: compiler-tester
           token: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           repository: matter-labs/compiler-tester
           path: compiler-tester
+          ref: az-cpr-532-implement-the-recursion-workaround
           submodules: recursive
           token: ${{ secrets.ZKSYNC_ADMIN_BOT_ORG_REPO_WRITE }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ include(EthCcache)
 # Let's find our dependencies
 include(EthDependencies)
 include(jsoncpp)
+include(range-v3)
 include_directories(SYSTEM ${JSONCPP_INCLUDE_DIR})
 
 find_package(Threads)

--- a/cmake/range-v3.cmake
+++ b/cmake/range-v3.cmake
@@ -1,0 +1,38 @@
+include(ExternalProject)
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+    set(RANGE_V3_CMAKE_COMMAND emcmake cmake)
+else()
+    set(RANGE_V3_CMAKE_COMMAND ${CMAKE_COMMAND})
+endif()
+
+set(prefix "${CMAKE_BINARY_DIR}/deps")
+set(RANGE_V3_INCLUDE_DIR "${prefix}/include")
+
+ExternalProject_Add(range-v3-project
+    PREFIX "${prefix}"
+    DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/deps/downloads"
+    DOWNLOAD_NAME range-v3-0.11.0.tar.gz
+    URL https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz
+    URL_HASH SHA256=376376615dbba43d3bef75aa590931431ecb49eb36d07bb726a19f680c75e20c
+    CMAKE_COMMAND ${RANGE_V3_CMAKE_COMMAND}
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+               -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+               -DBUILD_TESTING=OFF
+               -DRANGES_CXX_STD=${CMAKE_CXX_STANDARD}
+               -DRANGE_V3_DOCS=OFF
+               -DRANGE_V3_EXAMPLES=OFF
+               -DRANGE_V3_TESTS=OFF
+               -DRANGES_BUILD_CALENDAR_EXAMPLE=OFF
+               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    BUILD_BYPRODUCTS "${RANGE_V3_INCLUDE_DIR}/range/v3/all.hpp"
+)
+
+# Create range-v3 imported library
+add_library(range-v3 INTERFACE IMPORTED)
+file(MAKE_DIRECTORY ${RANGE_V3_INCLUDE_DIR})  # Must exist.
+set_target_properties(range-v3 PROPERTIES
+    INTERFACE_COMPILE_OPTIONS "\$<\$<CXX_COMPILER_ID:MSVC>:/permissive->"
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${RANGE_V3_INCLUDE_DIR}
+    INTERFACE_INCLUDE_DIRECTORIES ${RANGE_V3_INCLUDE_DIR})
+add_dependencies(range-v3 range-v3-project)

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -354,7 +354,7 @@ Assembly& Assembly::optimise(bool _enable, EVMVersion _evmVersion, bool _isCreat
 
 Assembly& Assembly::optimise(OptimiserSettings const& _settings)
 {
-	optimiseInternal(_settings, {});
+	(void) _settings;
 	return *this;
 }
 

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -14,6 +14,8 @@ set(sources
 	analysis/DeclarationContainer.h
 	analysis/DocStringAnalyser.cpp
 	analysis/DocStringAnalyser.h
+	analysis/FunctionCallGraph.cpp
+	analysis/FunctionCallGraph.h
 	analysis/GlobalContext.cpp
 	analysis/GlobalContext.h
 	analysis/NameAndTypeResolver.cpp
@@ -48,6 +50,8 @@ set(sources
 	ast/ASTJsonImporter.cpp
 	ast/ASTJsonImporter.h
 	ast/ASTVisitor.h
+	ast/CallGraph.cpp
+	ast/CallGraph.h
 	ast/ExperimentalFeatures.h
 	ast/Types.cpp
 	ast/Types.h
@@ -67,6 +71,10 @@ set(sources
 	codegen/ContractCompiler.h
 	codegen/ExpressionCompiler.cpp
 	codegen/ExpressionCompiler.h
+	codegen/ExtraMetadata.cpp
+	codegen/ExtraMetadata.h
+	codegen/FuncPtrTracker.cpp
+	codegen/FuncPtrTracker.h
 	codegen/LValue.cpp
 	codegen/LValue.h
 	codegen/MultiUseYulFunctionCollector.h

--- a/libsolidity/analysis/FunctionCallGraph.cpp
+++ b/libsolidity/analysis/FunctionCallGraph.cpp
@@ -1,0 +1,335 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/analysis/FunctionCallGraph.h>
+
+#include <libsolutil/StringUtils.h>
+
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/reverse.hpp>
+#include <range/v3/view/transform.hpp>
+
+using namespace std;
+using namespace ranges;
+using namespace solidity::frontend;
+using namespace solidity::util;
+
+CallGraph FunctionCallGraphBuilder::buildCreationGraph(ContractDefinition const& _contract)
+{
+	FunctionCallGraphBuilder builder(_contract);
+	solAssert(builder.m_currentNode == CallGraph::Node(CallGraph::SpecialNode::Entry), "");
+
+	// Create graph for constructor, state vars, etc
+	for (ContractDefinition const* base: _contract.annotation().linearizedBaseContracts | views::reverse)
+	{
+		// The constructor and functions called in state variable initial assignments should have
+		// an edge from Entry
+		builder.m_currentNode = CallGraph::SpecialNode::Entry;
+		for (auto const* stateVar: base->stateVariables())
+			if (!stateVar->isConstant())
+				stateVar->accept(builder);
+
+		if (base->constructor())
+		{
+			builder.functionReferenced(*base->constructor());
+
+			// Constructors and functions called in state variable initializers have an edge either from
+			// the previous class in linearized order or from Entry if there's no class before.
+			builder.m_currentNode = base->constructor();
+		}
+
+		// Functions called from the inheritance specifier should have an edge from the constructor
+		// for consistency with functions called from constructor modifiers.
+		for (auto const& inheritanceSpecifier: base->baseContracts())
+			inheritanceSpecifier->accept(builder);
+	}
+
+	builder.m_currentNode = CallGraph::SpecialNode::Entry;
+	builder.processQueue();
+
+	return move(builder.m_graph);
+}
+
+CallGraph FunctionCallGraphBuilder::buildDeployedGraph(
+	ContractDefinition const& _contract,
+	CallGraph const& _creationGraph
+)
+{
+	FunctionCallGraphBuilder builder(_contract);
+	solAssert(builder.m_currentNode == CallGraph::Node(CallGraph::SpecialNode::Entry), "");
+
+	auto getSecondElement = [](auto const& _tuple){ return get<1>(_tuple); };
+
+	// Create graph for all publicly reachable functions
+	for (FunctionTypePointer functionType: _contract.interfaceFunctionList() | views::transform(getSecondElement))
+	{
+		auto const* function = dynamic_cast<FunctionDefinition const*>(&functionType->declaration());
+		auto const* variable = dynamic_cast<VariableDeclaration const*>(&functionType->declaration());
+
+		if (function)
+			builder.functionReferenced(*function);
+		else
+			// If it's not a function, it must be a getter of a public variable; we ignore those
+			solAssert(variable, "");
+	}
+
+	if (_contract.fallbackFunction())
+		builder.functionReferenced(*_contract.fallbackFunction());
+
+	if (_contract.receiveFunction())
+		builder.functionReferenced(*_contract.receiveFunction());
+
+	// All functions present in internal dispatch at creation time could potentially be pointers
+	// assigned to state variables and as such may be reachable after deployment as well.
+	builder.m_currentNode = CallGraph::SpecialNode::InternalDispatch;
+	for (CallGraph::Node const& dispatchTarget: valueOrDefault(_creationGraph.edges, CallGraph::SpecialNode::InternalDispatch, {}))
+	{
+		solAssert(!holds_alternative<CallGraph::SpecialNode>(dispatchTarget), "");
+		solAssert(get<CallableDeclaration const*>(dispatchTarget) != nullptr, "");
+
+		// Visit the callable to add not only it but also everything it calls too
+		builder.functionReferenced(*get<CallableDeclaration const*>(dispatchTarget), false);
+	}
+
+	builder.m_currentNode = CallGraph::SpecialNode::Entry;
+	builder.processQueue();
+
+	return move(builder.m_graph);
+}
+
+bool FunctionCallGraphBuilder::visit(FunctionCall const& _functionCall)
+{
+	if (_functionCall.annotation().kind != FunctionCallKind::FunctionCall)
+		return true;
+
+	auto const* functionType = dynamic_cast<FunctionType const*>(_functionCall.expression().annotation().type);
+	solAssert(functionType, "");
+
+	if (functionType->kind() == FunctionType::Kind::Internal && !_functionCall.expression().annotation().calledDirectly)
+	{
+		for (FunctionDefinition const* funcPtrRef: m_contract.annotation().intFuncPtrRefs)
+		{
+			FunctionType const* funcPtrRefType = funcPtrRef->functionType(/*_internal=*/true);
+			solAssert(funcPtrRefType, "");
+			if (!funcPtrRefType->hasEqualParameterTypes(*functionType)
+				|| !funcPtrRefType->hasEqualReturnTypes(*functionType) || !funcPtrRef->isImplemented())
+				continue;
+			m_graph.indirectEdges[m_currentNode].insert(funcPtrRef);
+		}
+		// If it's not a direct call, we don't really know which function will be called (it may even
+		// change at runtime). All we can do is to add an edge to the dispatch which in turn has
+		// edges to all functions could possibly be called.
+		add(m_currentNode, CallGraph::SpecialNode::InternalDispatch);
+	}
+
+	return true;
+}
+
+bool FunctionCallGraphBuilder::visit(EmitStatement const& _emitStatement)
+{
+	auto const* functionType = dynamic_cast<FunctionType const*>(_emitStatement.eventCall().expression().annotation().type);
+	solAssert(functionType, "");
+
+	m_graph.emittedEvents.insert(&dynamic_cast<EventDefinition const&>(functionType->declaration()));
+
+	return true;
+}
+
+bool FunctionCallGraphBuilder::visit(Identifier const& _identifier)
+{
+	if (auto const* variable = dynamic_cast<VariableDeclaration const*>(_identifier.annotation().referencedDeclaration))
+	{
+		if (variable->isConstant())
+		{
+			solAssert(variable->isStateVariable(), "");
+			variable->accept(*this);
+		}
+	}
+	else if (auto const* callable = dynamic_cast<CallableDeclaration const*>(_identifier.annotation().referencedDeclaration))
+	{
+		solAssert(*_identifier.annotation().requiredLookup == VirtualLookup::Virtual, "");
+
+		auto funType = dynamic_cast<FunctionType const*>(_identifier.annotation().type);
+
+		// For events kind() == Event, so we have an extra check here
+		if (funType && funType->kind() == FunctionType::Kind::Internal)
+			functionReferenced(callable->resolveVirtual(m_contract), _identifier.annotation().calledDirectly);
+	}
+
+	return true;
+}
+
+bool FunctionCallGraphBuilder::visit(MemberAccess const& _memberAccess)
+{
+	auto functionType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type);
+	auto functionDef = dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration);
+	if (!functionType || !functionDef || functionType->kind() != FunctionType::Kind::Internal)
+		return true;
+
+	// Super functions
+	if (*_memberAccess.annotation().requiredLookup == VirtualLookup::Super)
+	{
+		if (auto const* contractType = dynamic_cast<ContractType const*>(_memberAccess.expression().annotation().type))
+		{
+			solAssert(contractType->isSuper(), "");
+			functionDef = &functionDef->resolveVirtual(
+				m_contract,
+				contractType->contractDefinition().superContract(m_contract)
+			);
+		}
+	}
+	else
+		solAssert(*_memberAccess.annotation().requiredLookup == VirtualLookup::Static, "");
+
+	functionReferenced(*functionDef, _memberAccess.annotation().calledDirectly);
+
+	return true;
+}
+
+bool FunctionCallGraphBuilder::visit(ModifierInvocation const& _modifierInvocation)
+{
+	if (auto const* modifier = dynamic_cast<ModifierDefinition const*>(_modifierInvocation.name()->annotation().referencedDeclaration))
+	{
+		VirtualLookup const& requiredLookup = *_modifierInvocation.name()->annotation().requiredLookup;
+
+		if (requiredLookup == VirtualLookup::Virtual)
+			functionReferenced(modifier->resolveVirtual(m_contract));
+		else
+		{
+			solAssert(requiredLookup == VirtualLookup::Static, "");
+			functionReferenced(*modifier);
+		}
+	}
+
+	return true;
+}
+
+bool FunctionCallGraphBuilder::visit(NewExpression const& _newExpression)
+{
+	if (ContractType const* contractType = dynamic_cast<ContractType const*>(_newExpression.typeName().annotation().type))
+		m_graph.createdContracts.emplace(&contractType->contractDefinition());
+
+	return true;
+}
+
+void FunctionCallGraphBuilder::enqueueCallable(CallableDeclaration const& _callable)
+{
+	if (!m_graph.edges.count(&_callable))
+	{
+		m_visitQueue.push_back(&_callable);
+
+		// Insert the callable to the graph (with no edges coming out of it) to mark it as visited.
+		m_graph.edges.insert({CallGraph::Node(&_callable), {}});
+	}
+}
+
+void FunctionCallGraphBuilder::processQueue()
+{
+	solAssert(m_currentNode == CallGraph::Node(CallGraph::SpecialNode::Entry), "Visit queue is already being processed.");
+
+	while (!m_visitQueue.empty())
+	{
+		m_currentNode = m_visitQueue.front();
+		solAssert(holds_alternative<CallableDeclaration const*>(m_currentNode), "");
+
+		m_visitQueue.pop_front();
+		get<CallableDeclaration const*>(m_currentNode)->accept(*this);
+	}
+
+	m_currentNode = CallGraph::SpecialNode::Entry;
+}
+
+void FunctionCallGraphBuilder::add(CallGraph::Node _caller, CallGraph::Node _callee)
+{
+	m_graph.edges[_caller].insert(_callee);
+}
+
+void FunctionCallGraphBuilder::functionReferenced(CallableDeclaration const& _callable, bool _calledDirectly)
+{
+	if (_calledDirectly)
+	{
+		solAssert(
+			holds_alternative<CallGraph::SpecialNode>(m_currentNode) || m_graph.edges.count(m_currentNode) > 0,
+			"Adding an edge from a node that has not been visited yet."
+		);
+
+		add(m_currentNode, &_callable);
+	}
+	else
+		add(CallGraph::SpecialNode::InternalDispatch, &_callable);
+
+	enqueueCallable(_callable);
+}
+
+ostream& solidity::frontend::operator<<(ostream& _out, CallGraph::Node const& _node)
+{
+	if (holds_alternative<CallGraph::SpecialNode>(_node))
+		switch (get<CallGraph::SpecialNode>(_node))
+		{
+		case CallGraph::SpecialNode::InternalDispatch:
+			_out << "InternalDispatch";
+			break;
+		case CallGraph::SpecialNode::Entry:
+			_out << "Entry";
+			break;
+		default:
+			solAssert(false, "Invalid SpecialNode type");
+		}
+	else
+	{
+		solAssert(holds_alternative<CallableDeclaration const*>(_node), "");
+
+		auto const* callableDeclaration = get<CallableDeclaration const*>(_node);
+		solAssert(callableDeclaration, "");
+
+		auto const* function = dynamic_cast<FunctionDefinition const *>(callableDeclaration);
+		auto const* event = dynamic_cast<EventDefinition const *>(callableDeclaration);
+		auto const* modifier = dynamic_cast<ModifierDefinition const *>(callableDeclaration);
+
+		auto typeToString = [](auto const& _var) -> string { return _var->type()->toString(true); };
+		vector<string> parameters = callableDeclaration->parameters() | views::transform(typeToString) | to<vector<string>>();
+
+		string scopeName;
+		if (!function)
+		{
+			solAssert(callableDeclaration->annotation().scope, "");
+			auto const* parentContract = dynamic_cast<ContractDefinition const*>(callableDeclaration->annotation().scope);
+			solAssert(parentContract, "");
+			scopeName = parentContract->name();
+		}
+
+		if (function)
+			_out << "function " << function->name() << "(" << joinHumanReadable(parameters, ",") << ")";
+		else if (function && function->isConstructor())
+			_out << "constructor of " << scopeName;
+		else if (function && function->isFallback())
+			_out << "fallback of " << scopeName;
+		else if (function && function->isReceive())
+			_out << "receive of " << scopeName;
+		else if (function)
+			_out << "function " << scopeName << "." << function->name() << "(" << joinHumanReadable(parameters, ",") << ")";
+		else if (event)
+			_out << "event " << scopeName << "." << event->name() << "(" << joinHumanReadable(parameters, ",") << ")";
+		else if (modifier)
+			_out << "modifier " << scopeName << "." << modifier->name();
+		else
+			solAssert(false, "Unexpected AST node type in function call graph");
+	}
+
+	return _out;
+}

--- a/libsolidity/analysis/FunctionCallGraph.h
+++ b/libsolidity/analysis/FunctionCallGraph.h
@@ -1,0 +1,92 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libsolidity/ast/ASTForward.h>
+#include <libsolidity/ast/ASTVisitor.h>
+#include <libsolidity/ast/CallGraph.h>
+
+#include <deque>
+#include <ostream>
+
+namespace solidity::frontend
+{
+
+/**
+ * Creates a function call graph for a contract at the granularity of Solidity functions and modifiers.
+ * or after deployment. The graph does not preserve temporal relations between calls - edges
+ * coming out of the same node show which calls were performed but not in what order.
+ *
+ * Includes the following special nodes:
+ *  - Entry: represents a call from the outside of the contract.
+ *    After deployment this is the node that connects to all the functions exposed through the
+ *    external interface. At contract creation it connects to the constructors and variable
+ *    initializers, which are not explicitly called from within another function.
+ *  - InternalDispatch: Represents the internal dispatch function, which calls internal functions
+ *    determined at runtime by values of variables and expressions. Functions that are not called
+ *    right away get an edge from this node.
+ *
+ *  Nodes are a variant of either the enum SpecialNode or a CallableDeclaration which currently
+ *  can be a function or a modifier. There are no nodes representing event calls. Instead all
+ *  emitted events and created contracts are gathered in separate sets included in the graph just
+ *  for that purpose.
+ *
+ *  Auto-generated getter functions for public state variables are ignored, but function calls
+ *  inside initial assignments are included in the creation graph.
+ *
+ *  Only calls reachable from an Entry node are included in the graph. The map representing edges
+ *  is also guaranteed to contain keys representing all the reachable functions and modifiers, even
+ *  if they have no outgoing edges.
+ */
+class FunctionCallGraphBuilder: private ASTConstVisitor
+{
+public:
+	static CallGraph buildCreationGraph(ContractDefinition const& _contract);
+	static CallGraph buildDeployedGraph(
+		ContractDefinition const& _contract,
+		CallGraph const& _creationGraph
+	);
+
+private:
+	FunctionCallGraphBuilder(ContractDefinition const& _contract):
+		m_contract(_contract),
+		m_graph{{}, {}, {}} {}
+
+	bool visit(FunctionCall const& _functionCall) override;
+	bool visit(EmitStatement const& _emitStatement) override;
+	bool visit(Identifier const& _identifier) override;
+	bool visit(MemberAccess const& _memberAccess) override;
+	bool visit(ModifierInvocation const& _modifierInvocation) override;
+	bool visit(NewExpression const& _newExpression) override;
+
+	void enqueueCallable(CallableDeclaration const& _callable);
+	void processQueue();
+
+	void add(CallGraph::Node _caller, CallGraph::Node _callee);
+	void functionReferenced(CallableDeclaration const& _callable, bool _calledDirectly = true);
+
+	CallGraph::Node m_currentNode = CallGraph::SpecialNode::Entry;
+	ContractDefinition const& m_contract;
+	CallGraph m_graph;
+	std::deque<CallableDeclaration const*> m_visitQueue;
+};
+
+std::ostream& operator<<(std::ostream& _out, CallGraph::Node const& _node);
+
+}

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2126,6 +2126,15 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 		functionType = dynamic_cast<FunctionType const*>(expressionType);
 		funcCallAnno.kind = FunctionCallKind::FunctionCall;
 
+		if (auto memberAccess = dynamic_cast<MemberAccess const*>(&_functionCall.expression()))
+		{
+			if (dynamic_cast<FunctionDefinition const*>(memberAccess->annotation().referencedDeclaration))
+				_functionCall.expression().annotation().calledDirectly = true;
+		}
+		else if (auto identifier = dynamic_cast<Identifier const*>(&_functionCall.expression()))
+			if (dynamic_cast<FunctionDefinition const*>(identifier->annotation().referencedDeclaration))
+				_functionCall.expression().annotation().calledDirectly = true;
+
 		// Purity for function calls also depends upon the callee and its FunctionType
 		funcCallAnno.isPure =
 			argumentsArePure &&
@@ -2421,6 +2430,8 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 	TypePointer exprType = type(_memberAccess.expression());
 	ASTString const& memberName = _memberAccess.memberName();
 
+	auto& annotation = _memberAccess.annotation();
+
 	// Retrieve the types of the arguments if this is used to call a function.
 	auto const& arguments = _memberAccess.annotation().arguments;
 	MemberList::MemberMap possibleMembers = exprType->members(m_scope).membersByName(memberName);
@@ -2438,7 +2449,7 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 				++it;
 	}
 
-	auto& annotation = _memberAccess.annotation();
+	annotation.isConstant = false;
 
 	if (possibleMembers.empty())
 	{
@@ -2524,6 +2535,8 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 	annotation.referencedDeclaration = possibleMembers.front().declaration;
 	annotation.type = possibleMembers.front().type;
 
+	VirtualLookup requiredLookup = VirtualLookup::Static;
+
 	if (auto funType = dynamic_cast<FunctionType const*>(annotation.type))
 	{
 		solAssert(
@@ -2541,7 +2554,14 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 				_memberAccess.location(),
 				"Using \"." + memberName + "(...)\" is deprecated. Use \"{" + memberName + ": ...}\" instead."
 			);
+
+		if (!funType->bound())
+			if (auto contractType = dynamic_cast<ContractType const*>(exprType))
+				requiredLookup = contractType->isSuper() ? VirtualLookup::Super : VirtualLookup::Virtual;
+
 	}
+
+	annotation.requiredLookup = requiredLookup;
 
 	if (auto const* structType = dynamic_cast<StructType const*>(exprType))
 		annotation.isLValue = !structType->dataStoredIn(DataLocation::CallData);
@@ -2845,6 +2865,10 @@ bool TypeChecker::visit(Identifier const& _identifier)
 	else if (dynamic_cast<TypeType const*>(annotation.type))
 		annotation.isPure = true;
 
+
+	annotation.requiredLookup =
+		dynamic_cast<CallableDeclaration const*>(annotation.referencedDeclaration) ?
+		VirtualLookup::Virtual : VirtualLookup::Static;
 
 	// Check for deprecated function names.
 	// The check is done here for the case without an actual function call.

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -62,6 +62,24 @@ class ASTConstVisitor;
 class ASTNode: private boost::noncopyable
 {
 public:
+	struct CompareByID
+	{
+		using is_transparent = void;
+
+		bool operator()(ASTNode const* _lhs, ASTNode const* _rhs) const
+		{
+			return _lhs->id() < _rhs->id();
+		}
+		bool operator()(ASTNode const* _lhs, int64_t _rhs) const
+		{
+			return _lhs->id() < _rhs;
+		}
+		bool operator()(int64_t _lhs, ASTNode const* _rhs) const
+		{
+			return _lhs < _rhs->id();
+		}
+	};
+
 	using SourceLocation = langutil::SourceLocation;
 
 	explicit ASTNode(int64_t _id, SourceLocation const& _location);
@@ -500,6 +518,10 @@ public:
 
 	bool abstract() const { return m_abstract; }
 
+	ContractDefinition const* superContract(ContractDefinition const& _mostDerivedContract) const;
+	/// @returns the next constructor in the inheritance hierarchy.
+	FunctionDefinition const* nextConstructor(ContractDefinition const& _mostDerivedContract) const;
+
 private:
 	std::vector<ASTPointer<InheritanceSpecifier>> m_baseContracts;
 	std::vector<ASTPointer<ASTNode>> m_subNodes;
@@ -689,6 +711,18 @@ public:
 
 	CallableDeclarationAnnotation& annotation() const override = 0;
 
+	/// Performs virtual or super function/modifier lookup:
+	/// If @a _searchStart is nullptr, performs virtual function lookup, i.e.
+	/// searches the inheritance hierarchy of @a _mostDerivedContract towards the base
+	/// and returns the first function/modifier definition that
+	/// is overwritten by this callable.
+	/// If @a _searchStart is non-null, starts searching only from that contract, but
+	/// still in the hierarchy of @a _mostDerivedContract.
+	virtual CallableDeclaration const& resolveVirtual(
+		ContractDefinition const& _mostDerivedContract,
+		ContractDefinition const* _searchStart = nullptr
+	) const = 0;
+
 protected:
 	ASTPointer<ParameterList> m_parameters;
 	ASTPointer<OverrideSpecifier> m_overrides;
@@ -799,6 +833,12 @@ public:
 			CallableDeclaration::virtualSemantics() ||
 			(annotation().contract && annotation().contract->isInterface());
 	}
+
+	FunctionDefinition const& resolveVirtual(
+		ContractDefinition const& _mostDerivedContract,
+		ContractDefinition const* _searchStart = nullptr
+	) const override;
+
 private:
 	StateMutability m_stateMutability;
 	Token const m_kind;
@@ -944,6 +984,12 @@ public:
 
 	ModifierDefinitionAnnotation& annotation() const override;
 
+	ModifierDefinition const& resolveVirtual(
+		ContractDefinition const& _mostDerivedContract,
+		ContractDefinition const* _searchStart = nullptr
+	) const override;
+
+
 private:
 	ASTPointer<Block> m_body;
 };
@@ -1008,6 +1054,14 @@ public:
 	bool isVisibleViaContractTypeAccess() const override { return false; /* TODO */ }
 
 	EventDefinitionAnnotation& annotation() const override;
+
+	CallableDeclaration const& resolveVirtual(
+		ContractDefinition const&,
+		ContractDefinition const*
+	) const override
+	{
+		solAssert(false, "Tried to resolve virtual event.");
+	}
 
 private:
 	bool m_anonymous = false;

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -26,6 +26,10 @@
 #include <libsolidity/ast/ASTEnums.h>
 #include <libsolidity/ast/ExperimentalFeatures.h>
 
+#include <libsolutil/SetOnce.h>
+
+#include <libyul/AsmData.h>
+
 #include <map>
 #include <memory>
 #include <optional>
@@ -44,6 +48,8 @@ namespace solidity::frontend
 
 class Type;
 using TypePointer = Type const*;
+
+struct CallGraph;
 
 struct ASTAnnotation
 {
@@ -114,6 +120,12 @@ struct ContractDefinitionAnnotation: TypeDeclarationAnnotation, StructurallyDocu
 	/// Mapping containing the nodes that define the arguments for base constructors.
 	/// These can either be inheritance specifiers or modifier invocations.
 	std::map<FunctionDefinition const*, ASTNode const*> baseConstructorArguments;
+	/// A graph with edges representing calls between functions that may happen during contract construction.
+	util::SetOnce<std::shared_ptr<CallGraph const>> creationCallGraph;
+	/// A graph with edges representing calls between functions that may happen in a deployed contract.
+	util::SetOnce<std::shared_ptr<CallGraph const>> deployedCallGraph;
+	/// Set of internal functions referenced as function pointers
+	std::set<FunctionDefinition const*> intFuncPtrRefs;
 };
 
 struct CallableDeclarationAnnotation: DeclarationAnnotation
@@ -160,6 +172,8 @@ struct InlineAssemblyAnnotation: StatementAnnotation
 	std::map<yul::Identifier const*, ExternalIdentifierInfo> externalReferences;
 	/// Information generated during analysis phase.
 	std::shared_ptr<yul::AsmAnalysisInfo> analysisInfo;
+	/// The yul block of the InlineAssembly::operations() after optimizations.
+	std::shared_ptr<yul::Block> optimizedOperations;
 };
 
 struct BlockAnnotation: StatementAnnotation, ScopableAnnotation
@@ -212,12 +226,23 @@ struct ExpressionAnnotation: ASTAnnotation
 	/// Types and - if given - names of arguments if the expr. is a function
 	/// that is called, used for overload resoultion
 	std::optional<FuncCallArguments> arguments;
+
+	/// True if the expression consists solely of the name of the function and the function is called immediately
+	/// instead of being stored or processed. The name may be qualified with the name of a contract, library
+	/// module, etc., that clarifies the scope. For example: `m.L.f()`, where `m` is a module, `L` is a library
+	/// and `f` is a function is a direct call. This means that the function to be called is known at compilation
+	/// time and it's not necessary to rely on any runtime dispatch mechanism to resolve it.
+	/// Note that even the simplest expressions, like `(f)()`, result in an indirect call even if they consist of
+	/// values known at compilation time.
+	bool calledDirectly = false;
 };
 
 struct IdentifierAnnotation: ExpressionAnnotation
 {
 	/// Referenced declaration, set at latest during overload resolution stage.
 	Declaration const* referencedDeclaration = nullptr;
+	/// What kind of lookup needs to be done (static, virtual, super) find the declaration.
+	util::SetOnce<VirtualLookup> requiredLookup;
 	/// List of possible declarations it could refer to.
 	std::vector<Declaration const*> overloadedDeclarations;
 };
@@ -226,6 +251,8 @@ struct MemberAccessAnnotation: ExpressionAnnotation
 {
 	/// Referenced declaration, set at latest during overload resolution stage.
 	Declaration const* referencedDeclaration = nullptr;
+	/// What kind of lookup needs to be done (static, virtual, super) find the declaration.
+	util::SetOnce<VirtualLookup> requiredLookup;
 };
 
 struct BinaryOperationAnnotation: ExpressionAnnotation

--- a/libsolidity/ast/ASTEnums.h
+++ b/libsolidity/ast/ASTEnums.h
@@ -29,6 +29,9 @@
 namespace solidity::frontend
 {
 
+/// Possible lookups for function resolving
+enum class VirtualLookup { Static, Virtual, Super };
+
 // How a function can mutate the EVM state.
 enum class StateMutability { Pure, View, NonPayable, Payable };
 

--- a/libsolidity/ast/CallGraph.cpp
+++ b/libsolidity/ast/CallGraph.cpp
@@ -1,0 +1,175 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/ast/CallGraph.h>
+
+using namespace std;
+using namespace solidity::frontend;
+
+bool CallGraph::CompareByID::operator()(Node const& _lhs, Node const& _rhs) const
+{
+	if (_lhs.index() != _rhs.index())
+		return _lhs.index() < _rhs.index();
+
+	if (holds_alternative<SpecialNode>(_lhs))
+		return get<SpecialNode>(_lhs) < get<SpecialNode>(_rhs);
+	return get<CallableDeclaration const*>(_lhs)->id() < get<CallableDeclaration const*>(_rhs)->id();
+}
+
+bool CallGraph::CompareByID::operator()(Node const& _lhs, int64_t _rhs) const
+{
+	solAssert(!holds_alternative<SpecialNode>(_lhs), "");
+
+	return get<CallableDeclaration const*>(_lhs)->id() < _rhs;
+}
+
+bool CallGraph::CompareByID::operator()(int64_t _lhs, Node const& _rhs) const
+{
+	solAssert(!holds_alternative<SpecialNode>(_rhs), "");
+
+	return _lhs < get<CallableDeclaration const*>(_rhs)->id();
+}
+
+/// Populates reachable cycles from m_src into paths;
+class CycleFinder
+{
+	CallGraph const& m_callGraph;
+	CallableDeclaration const* m_src;
+	set<CallableDeclaration const*> m_processing;
+	set<CallableDeclaration const*> m_processed;
+	vector<CallGraph::Path> m_paths;
+
+	/// Populates `m_paths` with cycles reachable from @a _callable
+	void getCyclesInternal(CallableDeclaration const* _callable, CallGraph::Path& _path)
+	{
+		if (m_processed.count(_callable))
+			return;
+
+		auto directCallees = m_callGraph.edges.find(_callable);
+		auto indirectCallees = m_callGraph.indirectEdges.find(_callable);
+		// Is _callable a leaf node?
+		if (directCallees == m_callGraph.edges.end() && indirectCallees == m_callGraph.indirectEdges.end())
+		{
+			solAssert(m_processing.count(_callable) == 0, "");
+			m_processed.insert(_callable);
+			return;
+		}
+
+		m_processing.insert(_callable);
+		_path.push_back(_callable);
+
+		// Traverse all the direct and indirect callees
+		set<CallGraph::Node, CallGraph::CompareByID> callees;
+		if (directCallees != m_callGraph.edges.end())
+			callees.insert(directCallees->second.begin(), directCallees->second.end());
+		if (indirectCallees != m_callGraph.indirectEdges.end())
+			callees.insert(indirectCallees->second.begin(), indirectCallees->second.end());
+		for (auto const& calleeVariant: callees)
+		{
+			if (!holds_alternative<CallableDeclaration const*>(calleeVariant))
+				continue;
+			auto* callee = get<CallableDeclaration const*>(calleeVariant);
+
+			if (m_processing.count(callee))
+			{
+				// Extract the cycle
+				auto cycleStart = std::find(_path.begin(), _path.end(), callee);
+				solAssert(cycleStart != _path.end(), "");
+				m_paths.emplace_back(cycleStart, _path.end());
+				continue;
+			}
+
+			getCyclesInternal(callee, _path);
+		}
+
+		m_processing.erase(_callable);
+		m_processed.insert(_callable);
+		_path.pop_back();
+	}
+
+public:
+	CycleFinder(CallGraph const& _callGraph, CallableDeclaration const* _src): m_callGraph(_callGraph), m_src(_src) {}
+
+	vector<CallGraph::Path> getCycles()
+	{
+		CallGraph::Path p;
+		getCyclesInternal(m_src, p);
+		return m_paths;
+	}
+
+	void dump(ostream& _out)
+	{
+		for (CallGraph::Path const& path: m_paths)
+		{
+			for (CallableDeclaration const* func: path)
+				_out << func->name() << " -> ";
+			_out << "\n";
+		}
+	}
+};
+
+void CallGraph::getReachableFuncs(CallableDeclaration const* _src, std::set<CallableDeclaration const*>& _funcs) const
+{
+	if (_funcs.count(_src))
+		return;
+	_funcs.insert(_src);
+
+	auto directCallees = edges.find(_src);
+	auto indirectCallees = indirectEdges.find(_src);
+	// Is _src a leaf node?
+	if (directCallees == edges.end() && indirectCallees == indirectEdges.end())
+		return;
+
+	// Traverse all the direct and indirect callees
+	set<CallGraph::Node, CallGraph::CompareByID> callees;
+	if (directCallees != edges.end())
+		callees.insert(directCallees->second.begin(), directCallees->second.end());
+	if (indirectCallees != indirectEdges.end())
+		callees.insert(indirectCallees->second.begin(), indirectCallees->second.end());
+
+	for (auto const& calleeVariant: callees)
+	{
+		if (!holds_alternative<CallableDeclaration const*>(calleeVariant))
+			continue;
+		auto* callee = get<CallableDeclaration const*>(calleeVariant);
+		getReachableFuncs(callee, _funcs);
+	}
+}
+
+std::set<CallableDeclaration const*> CallGraph::getReachableFuncs(CallableDeclaration const* _src) const
+{
+	std::set<CallableDeclaration const*> funcs;
+	getReachableFuncs(_src, funcs);
+	return funcs;
+}
+
+std::set<CallableDeclaration const*> CallGraph::getReachableCycleFuncs(CallableDeclaration const* _src) const
+{
+	std::set<CallableDeclaration const*> funcs;
+	CycleFinder cf{*this, _src};
+	vector<CallGraph::Path> paths = cf.getCycles();
+
+	for (CallGraph::Path const& path: paths)
+	{
+		for (CallableDeclaration const* func: path)
+		{
+			funcs.insert(func);
+		}
+	}
+	return funcs;
+}

--- a/libsolidity/ast/CallGraph.h
+++ b/libsolidity/ast/CallGraph.h
@@ -1,0 +1,86 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+/// Data structure representing a function call graph.
+
+#pragma once
+
+#include <libsolidity/ast/AST.h>
+
+#include <map>
+#include <set>
+#include <variant>
+
+namespace solidity::frontend
+{
+
+/**
+ * Function call graph for a contract at the granularity of Solidity functions and modifiers.
+ * The graph can represent the situation either at contract creation or after deployment.
+ * The graph does not preserve temporal relations between calls - edges coming out of the same node
+ * show which calls were performed but not in what order.
+ *
+ * Stores also extra information about contracts that can be created and events that can be emitted
+ * from any of the functions in it.
+ */
+struct CallGraph
+{
+	enum class SpecialNode
+	{
+		InternalDispatch,
+		Entry,
+	};
+
+	using Node = std::variant<CallableDeclaration const*, SpecialNode>;
+	using Path = std::vector<CallableDeclaration const*>;
+
+	struct CompareByID
+	{
+		using is_transparent = void;
+		bool operator()(Node const& _lhs, Node const& _rhs) const;
+		bool operator()(Node const& _lhs, int64_t _rhs) const;
+		bool operator()(int64_t _lhs, Node const& _rhs) const;
+	};
+
+	/// Graph edges. Edges are directed and lead from the caller to the callee.
+	/// The map contains a key for every possible caller, even if does not actually perform
+	/// any calls.
+	std::map<Node, std::set<Node, CompareByID>, CompareByID> edges;
+
+	/// Contracts that may get created with `new` by functions present in the graph.
+	std::set<ContractDefinition const*, ASTNode::CompareByID> createdContracts;
+
+	/// Graph edges for indirect calls
+	std::map<Node, std::set<Node, CompareByID>, CompareByID> indirectEdges;
+
+	/// Events that may get emitted by functions present in the graph.
+	std::set<EventDefinition const*, ASTNode::CompareByID> emittedEvents;
+
+	/// Returns functions reachable from @a _src that belong to a cycle. Note that the cycle can be due to indirect
+	/// calls.
+	std::set<CallableDeclaration const*> getReachableCycleFuncs(CallableDeclaration const* _src) const;
+
+	/// Returns functions reachable (including the ones from indirect calls) from @a _src.
+	std::set<CallableDeclaration const*> getReachableFuncs(CallableDeclaration const* _src) const;
+
+private:
+	/// Populates @a _funcs with the functions reachable (including the ones from indirect calls) from @a _src.
+	void getReachableFuncs(CallableDeclaration const* _src, std::set<CallableDeclaration const*>& _funcs) const;
+};
+
+}

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -42,6 +42,8 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/algorithm/copy.hpp>
 
+#include <range/v3/view/enumerate.hpp>
+
 #include <limits>
 
 using namespace std;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1305,7 +1305,9 @@ private:
 	bool const m_arbitraryParameters = false;
 	bool const m_gasSet = false; ///< true iff the gas value to be used is on the stack
 	bool const m_valueSet = false; ///< true iff the value to be sent is on the stack
-	bool const m_bound = false; ///< true iff the function is called as arg1.fun(arg2, ..., argn)
+	/// true iff the function is called as arg1.fun(arg2, ..., argn).
+	/// This is achieved through the "using for" directive.
+	bool const m_bound = false;
 	Declaration const* m_declaration = nullptr;
 	bool m_saltSet = false; ///< true iff the salt value to be used is on the stack
 };

--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -285,6 +285,17 @@ void ArrayUtils::copyArrayToStorage(ArrayType const& _targetType, ArrayType cons
 			_context << Instruction::POP;
 		}
 	);
+
+	if (auto* structType = dynamic_cast<StructType const*>(_sourceType.baseType()))
+	{
+		if (structType->recursive())
+		{
+			string name{"$copyArrayToStorage_" + sourceType->identifier() + "_to_" + targetType->identifier()};
+			auto tag = m_context.lowLevelFunctionTagIfExists(name);
+			solAssert(tag != evmasm::AssemblyItem(evmasm::UndefinedItem), "");
+			m_context.addRecursiveLowLevelFunc({name, tag.data().convert_to<uint32_t>(), /*ins=*/3, /*outs=*/1});
+		}
+	}
 }
 
 void ArrayUtils::copyArrayToMemory(ArrayType const& _sourceType, bool _padToWordBoundaries) const
@@ -587,6 +598,17 @@ void ArrayUtils::clearArray(ArrayType const& _typeIn) const
 			solAssert(_context.stackHeight() == stackHeightStart - 2, "");
 		}
 	);
+
+	if (auto* structType = dynamic_cast<StructType const*>(_typeIn.baseType()))
+	{
+		if (structType->recursive())
+		{
+			string name{"$clearArray_" + _typeIn.identifier()};
+			auto tag = m_context.lowLevelFunctionTagIfExists(name);
+			solAssert(tag != evmasm::AssemblyItem(evmasm::UndefinedItem), "");
+			m_context.addRecursiveLowLevelFunc({name, tag.data().convert_to<uint32_t>(), /*ins=*/2, /*outs=*/0});
+		}
+	}
 }
 
 void ArrayUtils::clearDynamicArray(ArrayType const& _type) const

--- a/libsolidity/codegen/Compiler.cpp
+++ b/libsolidity/codegen/Compiler.cpp
@@ -23,6 +23,8 @@
 #include <libsolidity/codegen/Compiler.h>
 
 #include <libsolidity/codegen/ContractCompiler.h>
+#include <libsolidity/codegen/ExtraMetadata.h>
+
 #include <libevmasm/Assembly.h>
 
 using namespace std;
@@ -49,6 +51,9 @@ void Compiler::compileContract(
 	m_runtimeSub = creationCompiler.compileConstructor(_contract, _otherCompilers);
 
 	m_context.optimise(m_optimiserSettings);
+
+	ExtraMetadataRecorder extraMetadataRecorder{m_context, m_runtimeContext};
+	m_extraMetadata = extraMetadataRecorder.run(_contract);
 }
 
 std::shared_ptr<evmasm::Assembly> Compiler::runtimeAssemblyPtr() const

--- a/libsolidity/codegen/Compiler.h
+++ b/libsolidity/codegen/Compiler.h
@@ -73,11 +73,14 @@ public:
 	/// @returns Assembly items of the runtime compiler context
 	evmasm::AssemblyItems const& runtimeAssemblyItems() const { return m_context.assembly().sub(m_runtimeSub).items(); }
 
+	Json::Value extraMetadata() const { return m_extraMetadata; }
+
 	/// @returns the entry label of the given function. Might return an AssemblyItem of type
 	/// UndefinedItem if it does not exist yet.
 	evmasm::AssemblyItem functionEntryLabel(FunctionDefinition const& _function) const;
 
 private:
+	Json::Value m_extraMetadata;
 	OptimiserSettings const m_optimiserSettings;
 	CompilerContext m_runtimeContext;
 	size_t m_runtimeSub = size_t(-1); ///< Identifier of the runtime sub-assembly, if present.

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -127,6 +127,15 @@ evmasm::AssemblyItem CompilerContext::lowLevelFunctionTag(
 		return it->second;
 }
 
+evmasm::AssemblyItem CompilerContext::lowLevelFunctionTagIfExists(string const& _name)
+{
+	auto it = m_lowLevelFunctions.find(_name);
+	if (it == m_lowLevelFunctions.end())
+		return evmasm::AssemblyItem(evmasm::UndefinedItem);
+	else
+		return it->second;
+}
+
 void CompilerContext::appendMissingLowLevelFunctions()
 {
 	while (!m_lowLevelFunctionGenerationQueue.empty())
@@ -254,6 +263,12 @@ FunctionDefinition const* CompilerContext::nextConstructor(ContractDefinition co
 Declaration const* CompilerContext::nextFunctionToCompile() const
 {
 	return m_functionCompilationQueue.nextFunctionToCompile();
+}
+
+ContractDefinition const& CompilerContext::mostDerivedContract() const
+{
+	solAssert(m_mostDerivedContract, "Most derived contract not set.");
+	return *m_mostDerivedContract;
 }
 
 ModifierDefinition const& CompilerContext::resolveVirtualFunctionModifier(
@@ -463,11 +478,13 @@ void CompilerContext::appendInlineAssembly(
 		reportError("Failed to analyze inline assembly block.");
 
 	solAssert(errorReporter.errors().empty(), "Failed to analyze inline assembly block.");
+	shared_ptr<yul::CodeTransformContext> yulContext;
 	yul::CodeGenerator::assemble(
 		*parserResult,
 		analysisInfo,
 		*m_asm,
 		m_evmVersion,
+		yulContext,
 		identifierAccess,
 		_system,
 		_optimiserSettings.optimizeStackAllocation

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -38,6 +38,7 @@
 
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/backends/evm/EVMDialect.h>
+#include <libyul/backends/evm/EVMCodeTransform.h>
 
 #include <functional>
 #include <ostream>
@@ -112,6 +113,9 @@ public:
 	FunctionDefinition const* nextConstructor(ContractDefinition const& _contract) const;
 	/// Sets the current inheritance hierarchy from derived to base.
 	void setInheritanceHierarchy(std::vector<ContractDefinition const*> const& _hierarchy) { m_inheritanceHierarchy = _hierarchy; }
+    /// Sets the contract currently being compiled - the most derived one.
+    void setMostDerivedContract(ContractDefinition const& _contract) { m_mostDerivedContract = &_contract; }
+    ContractDefinition const& mostDerivedContract() const;
 
 	/// @returns the next function in the queue of functions that are still to be compiled
 	/// (i.e. that were referenced during compilation but where we did not yet generate code for).
@@ -150,6 +154,10 @@ public:
 		unsigned _outArgs,
 		std::function<void(CompilerContext&)> const& _generator
 	);
+	/// Returns the entry tag of the low-level function with the name @a _name if already generated; Returns
+	/// evmasm::AssemblyItem(evmasm::UndefinedItem) if the entry tag is not generated.
+	evmasm::AssemblyItem lowLevelFunctionTagIfExists(std::string const& _name);
+
 	/// Generates the code for missing low-level functions, i.e. calls the generators passed above.
 	void appendMissingLowLevelFunctions();
 	ABIFunctions& abiFunctions() { return m_abiFunctions; }
@@ -285,6 +293,40 @@ public:
 	evmasm::LinkerObject const& assembledObject() const { return m_asm->assemble(); }
 	evmasm::LinkerObject const& assembledRuntimeObject(size_t _subIndex) const { return m_asm->sub(_subIndex).assemble(); }
 
+	/// Adds the @a _asm -> @a _context mapping in the internal inline assembly to context mapping
+	void addInlineAsmContextMapping(InlineAssembly const* _asm, std::shared_ptr<yul::CodeTransformContext> _context)
+	{
+		m_inlineAsmContextMap[_asm] = _context;
+	}
+
+	/// Returns the context for @a _asm; nullptr if not found
+	yul::CodeTransformContext const* findInlineAsmContextMapping(InlineAssembly const* _asm) const
+	{
+		auto findIt = m_inlineAsmContextMap.find(_asm);
+		if (findIt == m_inlineAsmContextMap.end())
+			return nullptr;
+		return findIt->second.get();
+	}
+
+	struct FunctionInfo
+	{
+		std::string const name;
+		unsigned tag;
+		unsigned ins;
+		unsigned outs;
+
+		bool operator<(FunctionInfo const& _other) const
+		{
+			return tie(name, tag, ins, outs) < tie(_other.name, _other.tag, _other.ins, _other.outs);
+		}
+	};
+
+	/// Adds @a _func to the set of low level utility functions that are recursive
+	void addRecursiveLowLevelFunc(FunctionInfo _func) { m_recursiveLowLevelFuncs.insert(_func); }
+
+	/// Returns the set of low level utility functions that are recursive
+	std::set<FunctionInfo> const& recursiveLowLevelFuncs() const { return m_recursiveLowLevelFuncs; }
+
 	/**
 	 * Helper class to pop the visited nodes stack when a scope closes
 	 */
@@ -367,6 +409,8 @@ private:
 	std::map<Declaration const*, std::vector<unsigned>> m_localVariables;
 	/// List of current inheritance hierarchy from derived to base.
 	std::vector<ContractDefinition const*> m_inheritanceHierarchy;
+    /// The contract currently being compiled. Virtual function lookup starts from this contarct.
+    ContractDefinition const* m_mostDerivedContract = nullptr;
 	/// Stack of current visited AST nodes, used for location attachment
 	std::stack<ASTNode const*> m_visitedNodes;
 	/// The runtime context if in Creation mode, this is used for generating tags that would be stored into the storage and then used at runtime.
@@ -385,6 +429,10 @@ private:
 	YulUtilFunctions m_yulUtilFunctions;
 	/// The queue of low-level functions to generate.
 	std::queue<std::tuple<std::string, unsigned, unsigned, std::function<void(CompilerContext&)>>> m_lowLevelFunctionGenerationQueue;
+	/// Maps an InlineAssembly AST node to its CodeTransformContext created during its lowering
+	std::map<InlineAssembly const*, std::shared_ptr<yul::CodeTransformContext>> m_inlineAsmContextMap;
+	/// Set of low level utility functions generated in this context that are recursive
+	std::set<FunctionInfo> m_recursiveLowLevelFuncs;
 };
 
 }

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1041,12 +1041,21 @@ void CompilerUtils::convertType(
 					_context << Instruction::POP << Instruction::POP;
 				};
 				if (typeOnStack.recursive())
+				{
 					m_context.callLowLevelFunction(
 						"$convertRecursiveArrayStorageToMemory_" + typeOnStack.identifier() + "_to_" + targetType.identifier(),
 						1,
 						1,
 						conversionImpl
 					);
+					string name{
+						"$convertRecursiveArrayStorageToMemory_" + typeOnStack.identifier() + "_to_"
+						+ targetType.identifier()};
+					auto tag = m_context.lowLevelFunctionTagIfExists(name);
+					solAssert(tag != evmasm::AssemblyItem(evmasm::UndefinedItem), "");
+					m_context.addRecursiveLowLevelFunc(
+						{name, tag.data().convert_to<uint32_t>(), /*ins=*/1, /*outs=*/1});
+				}
 				else
 					conversionImpl(m_context);
 				break;

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -469,6 +469,68 @@ bool ExpressionCompiler::visit(BinaryOperation const& _binaryOperation)
 	return false;
 }
 
+void ExpressionCompiler::generateSelector(FunctionType const& _funcType)
+{
+	// Are we in the creation context?
+	if (m_context.runtimeContext())
+	{
+		// Extract only the low 32 bits for matching in the tag selector
+		m_context << u256(0xffffffff) << Instruction::AND;
+	}
+
+	struct TagInfo
+	{
+		evmasm::AssemblyItem const tag;
+		FunctionDefinition const* func;
+	};
+	vector<TagInfo> tagInfos;
+
+	for (auto* intFuncPtrRef: m_context.mostDerivedContract().annotation().intFuncPtrRefs)
+	{
+		FunctionType const* intFuncPtrRefType = intFuncPtrRef->functionType(true);
+		// ContractDefinitionAnnotation::intFuncPtrRefs should only contain refs to internal functions
+		solAssert(intFuncPtrRefType, "");
+		if (!intFuncPtrRefType->hasEqualParameterTypes(_funcType) || !intFuncPtrRefType->hasEqualReturnTypes(_funcType)
+			|| !intFuncPtrRef->isImplemented())
+			continue;
+
+		// The loaded function pointer
+		m_context << Instruction::DUP1;
+		// We don't need to resolve the function here since FuncPtrTracker already did that.
+		m_context << m_context.functionEntryLabel(*intFuncPtrRef).pushTag();
+		m_context << Instruction::EQ;
+
+		evmasm::AssemblyItem newTag = m_context.newTag();
+		m_context.appendConditionalJumpTo(newTag);
+		tagInfos.push_back({newTag, intFuncPtrRef});
+	}
+
+	if (tagInfos.empty())
+	{
+		// Pop the original function pointer
+		m_context << Instruction::POP;
+	}
+	// If we can't match the entry tag of any of the internal function
+	m_context.appendInvalid();
+
+	unsigned int stkOffsetAfterJumpI = m_context.stackHeight();
+	for (TagInfo& tagInfo: tagInfos)
+	{
+		// The PC is set to this tag from the jumpi, so we need to set the stack offset correctly
+		m_context.setStackOffset((int) stkOffsetAfterJumpI);
+
+		m_context << tagInfo.tag;
+
+		// Pop the original function pointer
+		m_context << Instruction::POP;
+
+		// We don't need to resolve the function here since FuncPtrTracker already did that.
+		m_context << m_context.functionEntryLabel(*tagInfo.func).pushTag();
+		m_context.appendJump(evmasm::AssemblyItem::JumpType::IntoFunction);
+		// After the call, the vm's pc should be set to the return label since it is pushed to the stack.
+	}
+}
+
 bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 {
 	CompilerContext::LocationSetter locationSetter(m_context, _functionCall);
@@ -572,6 +634,7 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 						// Do not directly visit the identifier, because this way, we can avoid
 						// the runtime entry label to be created at the creation time context.
 						CompilerContext::LocationSetter locationSetter2(m_context, *identifier);
+						solAssert(*identifier->annotation().requiredLookup == VirtualLookup::Virtual, "");
 						utils().pushCombinedFunctionEntryLabel(m_context.resolveVirtualFunction(*functionDef), false);
 						shortcutTaken = true;
 					}
@@ -590,6 +653,13 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				parameterSize += function.selfType()->sizeOnStack();
 			}
 
+			// There can be cases when ExpressionAnnotation::calledDirectly is false but we can infer that it is a
+			// direct call if the target PC is a literal tag
+			bool directCallInferred = false;
+			auto const& currAsmItems = m_context.assembly().items();
+			if (!currAsmItems.empty() && currAsmItems.back().type() == AssemblyItemType::PushTag)
+				directCallInferred = true;
+
 			if (m_context.runtimeContext())
 				// We have a runtime context, so we need the creation part.
 				utils().rightShiftNumberOnStack(32);
@@ -597,7 +667,12 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				// Extract the runtime part.
 				m_context << ((u256(1) << 32) - 1) << Instruction::AND;
 
-			m_context.appendJump(evmasm::AssemblyItem::JumpType::IntoFunction);
+			// Is this a direct call?
+			if (_functionCall.expression().annotation().calledDirectly || directCallInferred)
+				m_context.appendJump(evmasm::AssemblyItem::JumpType::IntoFunction);
+			else
+				generateSelector(function);
+
 			m_context << returnLabel;
 
 			unsigned returnParametersSize = CompilerUtils::sizeOnStack(function.returnParameterTypes());
@@ -1276,6 +1351,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 			if (funType->kind() == FunctionType::Kind::Internal)
 			{
 				FunctionDefinition const& funDef = dynamic_cast<decltype(funDef)>(funType->declaration());
+				solAssert(*_memberAccess.annotation().requiredLookup == VirtualLookup::Static, "");
 				utils().pushCombinedFunctionEntryLabel(funDef);
 				utils().moveIntoStack(funType->selfType()->sizeOnStack(), 1);
 			}
@@ -1311,7 +1387,10 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 					// internal library function call, this would push the library address forcing
 					// us to link against it although we actually do not need it.
 					if (auto const* function = dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration))
+					{
+						solAssert(*_memberAccess.annotation().requiredLookup == VirtualLookup::Static, "");
 						utils().pushCombinedFunctionEntryLabel(*function);
+					}
 					else
 						solAssert(false, "Function not found in member access");
 					break;
@@ -1425,6 +1504,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 		if (type.isSuper())
 		{
 			solAssert(!!_memberAccess.annotation().referencedDeclaration, "Referenced declaration not resolved.");
+			solAssert(*_memberAccess.annotation().requiredLookup == VirtualLookup::Super, "");
 			utils().pushCombinedFunctionEntryLabel(m_context.superFunction(
 				dynamic_cast<FunctionDefinition const&>(*_memberAccess.annotation().referencedDeclaration),
 				type.contractDefinition()
@@ -1863,11 +1943,14 @@ void ExpressionCompiler::endVisit(Identifier const& _identifier)
 		}
 	}
 	else if (FunctionDefinition const* functionDef = dynamic_cast<FunctionDefinition const*>(declaration))
+	{
 		// If the identifier is called right away, this code is executed in visit(FunctionCall...), because
 		// we want to avoid having a reference to the runtime function entry point in the
 		// constructor context, since this would force the compiler to include unreferenced
 		// internal functions in the runtime contex.
+		solAssert(*_identifier.annotation().requiredLookup == VirtualLookup::Virtual, "");
 		utils().pushCombinedFunctionEntryLabel(m_context.resolveVirtualFunction(*functionDef));
+	}
 	else if (auto variable = dynamic_cast<VariableDeclaration const*>(declaration))
 		appendVariable(*variable, static_cast<Expression const&>(_identifier));
 	else if (auto contract = dynamic_cast<ContractDefinition const*>(declaration))

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -137,6 +137,9 @@ private:
 	/// @returns the CompilerUtils object containing the current context.
 	CompilerUtils utils();
 
+	/// Generates the selector for internal function pointer with type @a _funcType.
+	void generateSelector(FunctionType const& _funcType);
+
 	bool m_optimiseOrderLiterals;
 	CompilerContext& m_context;
 	std::unique_ptr<LValue> m_currentLValue;

--- a/libsolidity/codegen/ExtraMetadata.cpp
+++ b/libsolidity/codegen/ExtraMetadata.cpp
@@ -1,0 +1,182 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/codegen/ExtraMetadata.h>
+
+#include <libsolidity/ast/CallGraph.h>
+#include <libsolidity/codegen/FuncPtrTracker.h>
+
+#include <libyul/optimiser/CallGraphGenerator.h>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::frontend;
+
+class InlineAsmRecursiveFuncRecorder: public ASTConstVisitor
+{
+public:
+	void run() { m_func.accept(*this); }
+
+	InlineAsmRecursiveFuncRecorder(
+		CallableDeclaration const& _func,
+		CompilerContext const& _context,
+		CompilerContext const& _runtimeContext,
+		Json::Value& _recFuncs)
+		: m_func(_func), m_context(_context), m_runtimeContext(_runtimeContext), m_recFuncs(_recFuncs)
+	{
+	}
+
+private:
+	CallableDeclaration const& m_func;
+	CompilerContext const& m_context;
+	CompilerContext const& m_runtimeContext;
+	Json::Value& m_recFuncs;
+
+	// Record recursions in @_asm for the extra metadata
+	void record(InlineAssembly const& _asm, CompilerContext const& _context)
+	{
+		auto findRes = _context.findInlineAsmContextMapping(&_asm);
+		if (!findRes)
+			return;
+		yul::CodeTransformContext const& yulContext = *findRes;
+
+		set<yul::YulString> recFuncs;
+		if (_asm.annotation().optimizedOperations)
+		{
+			yul::Block const& code = *_asm.annotation().optimizedOperations;
+			recFuncs = yul::CallGraphGenerator::callGraph(code).recursiveFunctions();
+		}
+		else
+		{
+			recFuncs = yul::CallGraphGenerator::callGraph(_asm.operations()).recursiveFunctions();
+		}
+		for (auto recFunc: recFuncs)
+		{
+			auto findIt = yulContext.functionInfoMap.find(recFunc);
+			if (findIt == yulContext.functionInfoMap.end())
+				continue;
+			for (auto& func: findIt->second)
+			{
+				Json::Value record(Json::objectValue);
+				record["name"] = recFunc.str();
+				if (_context.runtimeContext())
+					record["creationTag"] = func.label;
+				else
+					record["runtimeTag"] = func.label;
+				record["totalParamSize"] = func.ins;
+				record["totalRetParamSize"] = func.outs;
+				m_recFuncs.append(record);
+			}
+		}
+	}
+
+	void endVisit(InlineAssembly const& _asm)
+	{
+		record(_asm, m_context);
+		record(_asm, m_runtimeContext);
+	}
+};
+
+Json::Value ExtraMetadataRecorder::run(ContractDefinition const& _contract)
+{
+	// Set "recursiveFunctions"
+	Json::Value recFuncs(Json::arrayValue);
+
+	// Record recursions in low level calls
+	auto recordRecursiveLowLevelFuncs = [&](CompilerContext const& _context)
+	{
+		for (auto fn: _context.recursiveLowLevelFuncs())
+		{
+			Json::Value func(Json::objectValue);
+			func["name"] = fn.name;
+			if (_context.runtimeContext())
+				func["creationTag"] = fn.tag;
+			else
+				func["runtimeTag"] = fn.tag;
+			func["totalParamSize"] = fn.ins;
+			func["totalRetParamSize"] = fn.outs;
+			recFuncs.append(func);
+		}
+	};
+	recordRecursiveLowLevelFuncs(m_context);
+	recordRecursiveLowLevelFuncs(m_runtimeContext);
+
+	// Get reachable functions from the call-graphs; And get cycles in the call-graphs
+	auto& creationCallGraph = _contract.annotation().creationCallGraph;
+	auto& runtimeCallGraph = _contract.annotation().deployedCallGraph;
+
+	set<CallableDeclaration const*> reachableCycleFuncs, reachableFuncs;
+
+	for (FunctionDefinition const* fn: _contract.definedFunctions())
+	{
+		if (fn->isConstructor() && creationCallGraph.set())
+		{
+			reachableCycleFuncs += (*creationCallGraph)->getReachableCycleFuncs(fn);
+			reachableFuncs += (*creationCallGraph)->getReachableFuncs(fn);
+		}
+		else if (runtimeCallGraph.set())
+		{
+			reachableCycleFuncs += (*runtimeCallGraph)->getReachableCycleFuncs(fn);
+			reachableFuncs += (*runtimeCallGraph)->getReachableFuncs(fn);
+		}
+	}
+
+	// Record recursions in inline assembly
+	for (auto* fn: reachableFuncs)
+	{
+		InlineAsmRecursiveFuncRecorder inAsmRecorder{*fn, m_context, m_runtimeContext, recFuncs};
+		inAsmRecorder.run();
+	}
+
+	// Record recursions in the solidity source
+	auto recordRecursiveSolFuncs = [&](CompilerContext const& _context)
+	{
+		for (auto* fn: reachableCycleFuncs)
+		{
+			evmasm::AssemblyItem const& tag = _context.functionEntryLabelIfExists(*fn);
+			if (tag == evmasm::AssemblyItem(evmasm::UndefinedItem))
+				continue;
+
+			Json::Value func(Json::objectValue);
+			func["name"] = fn->name();
+
+			// Assembly::new[Push]Tag() asserts that the tag is 32 bits
+			auto tagNum = tag.data().convert_to<uint32_t>();
+			if (_context.runtimeContext())
+				func["creationTag"] = tagNum;
+			else
+				func["runtimeTag"] = tagNum;
+
+			unsigned totalParamSize = 0, totalRetParamSize = 0;
+			for (auto& param: fn->parameters())
+				totalParamSize += param->type()->sizeOnStack();
+			func["totalParamSize"] = totalParamSize;
+			for (auto& param: fn->returnParameters())
+				totalRetParamSize += param->type()->sizeOnStack();
+			func["totalRetParamSize"] = totalRetParamSize;
+
+			recFuncs.append(func);
+		}
+	};
+	recordRecursiveSolFuncs(m_context);
+	recordRecursiveSolFuncs(m_runtimeContext);
+
+	if (!recFuncs.empty())
+		m_metadata["recursiveFunctions"] = recFuncs;
+	return m_metadata;
+}

--- a/libsolidity/codegen/ExtraMetadata.h
+++ b/libsolidity/codegen/ExtraMetadata.h
@@ -1,0 +1,53 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * The extra metadata recorder
+ */
+
+#include <libsolidity/ast/ASTForward.h>
+#include <libsolidity/codegen/CompilerContext.h>
+
+#include <json/value.h>
+
+#include <memory>
+
+#pragma once
+
+namespace solidity::frontend
+{
+
+class ExtraMetadataRecorder
+{
+	CompilerContext const& m_context;
+	CompilerContext const& m_runtimeContext;
+	/// The root JSON value of the metadata
+	/// Current mappings:
+	/// - "recursiveFunctions": array of functions involved in recursion
+	Json::Value m_metadata;
+
+public:
+	ExtraMetadataRecorder(CompilerContext const& _context, CompilerContext const& _runtimeContext)
+		: m_context(_context), m_runtimeContext(_runtimeContext)
+	{
+	}
+
+	/// Stores the extra metadata of @a _contract in `metadata`
+	Json::Value run(ContractDefinition const& _contract);
+};
+
+}

--- a/libsolidity/codegen/FuncPtrTracker.cpp
+++ b/libsolidity/codegen/FuncPtrTracker.cpp
@@ -1,0 +1,133 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/codegen/FuncPtrTracker.h>
+
+#include <liblangutil/Exceptions.h>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::frontend;
+
+void FuncPtrTracker::endVisit(Identifier const& _identifier)
+{
+	Declaration const* declaration = _identifier.annotation().referencedDeclaration;
+	FunctionDefinition const* functionDef = dynamic_cast<FunctionDefinition const*>(declaration);
+	if (!functionDef)
+		return;
+
+	solAssert(*_identifier.annotation().requiredLookup == VirtualLookup::Virtual, "");
+	FunctionDefinition const& resolvedFunctionDef = functionDef->resolveVirtual(m_contract);
+
+	solAssert(resolvedFunctionDef.functionType(true), "");
+	solAssert(resolvedFunctionDef.functionType(true)->kind() == FunctionType::Kind::Internal, "");
+	if (_identifier.annotation().calledDirectly)
+		return;
+	m_contract.annotation().intFuncPtrRefs.insert(&resolvedFunctionDef);
+}
+
+void FuncPtrTracker::endVisit(MemberAccess const& _memberAccess)
+{
+	auto memberFunctionType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type);
+
+	if (memberFunctionType && memberFunctionType->bound())
+	{
+		solAssert(*_memberAccess.annotation().requiredLookup == VirtualLookup::Static, "");
+		if (memberFunctionType->kind() == FunctionType::Kind::Internal)
+			m_contract.annotation().intFuncPtrRefs.insert(
+				&dynamic_cast<FunctionDefinition const&>(memberFunctionType->declaration()));
+	}
+
+	Type::Category objectCategory = _memberAccess.expression().annotation().type->category();
+	switch (objectCategory)
+	{
+	case Type::Category::Contract:
+	{
+		ContractType const& contractType
+			= dynamic_cast<ContractType const&>(*_memberAccess.expression().annotation().type);
+		if (contractType.isSuper())
+		{
+			solAssert(!!_memberAccess.annotation().referencedDeclaration, "Referenced declaration not resolved.");
+			ContractDefinition const* super = contractType.contractDefinition().superContract(m_contract);
+			solAssert(super, "Super contract not available.");
+			FunctionDefinition const& resolvedFunctionDef
+				= dynamic_cast<FunctionDefinition const&>(*_memberAccess.annotation().referencedDeclaration)
+					  .resolveVirtual(m_contract, super);
+
+			solAssert(resolvedFunctionDef.functionType(true), "");
+			solAssert(resolvedFunctionDef.functionType(true)->kind() == FunctionType::Kind::Internal, "");
+			m_contract.annotation().intFuncPtrRefs.insert(&resolvedFunctionDef);
+		}
+		else if (memberFunctionType && memberFunctionType->kind() == FunctionType::Kind::Internal)
+		{
+			if (auto const* function
+				= dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration))
+				m_contract.annotation().intFuncPtrRefs.insert(function);
+		}
+		break;
+	}
+	case Type::Category::TypeType:
+	{
+		Type const& actualType
+			= *dynamic_cast<TypeType const&>(*_memberAccess.expression().annotation().type).actualType();
+
+		if (actualType.category() == Type::Category::Contract)
+		{
+			ContractType const& contractType = dynamic_cast<ContractType const&>(actualType);
+			if (contractType.isSuper())
+			{
+				solAssert(!!_memberAccess.annotation().referencedDeclaration, "Referenced declaration not resolved.");
+				ContractDefinition const* super = contractType.contractDefinition().superContract(m_contract);
+				solAssert(super, "Super contract not available.");
+				FunctionDefinition const& resolvedFunctionDef
+					= dynamic_cast<FunctionDefinition const&>(*_memberAccess.annotation().referencedDeclaration)
+						  .resolveVirtual(m_contract, super);
+
+				solAssert(resolvedFunctionDef.functionType(true), "");
+				solAssert(resolvedFunctionDef.functionType(true)->kind() == FunctionType::Kind::Internal, "");
+				m_contract.annotation().intFuncPtrRefs.insert(&resolvedFunctionDef);
+			}
+			else if (memberFunctionType && memberFunctionType->kind() == FunctionType::Kind::Internal)
+			{
+				if (auto const* function
+					= dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration))
+					m_contract.annotation().intFuncPtrRefs.insert(function);
+			}
+		}
+		break;
+	}
+	case Type::Category::Module:
+	{
+		if (auto const* function
+			= dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration))
+		{
+			auto funType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type);
+			solAssert(function, "");
+			solAssert(function->functionType(true), "");
+			solAssert(function->functionType(true)->kind() == FunctionType::Kind::Internal, "");
+			solAssert(funType->kind() == FunctionType::Kind::Internal, "");
+			solAssert(*_memberAccess.annotation().requiredLookup == VirtualLookup::Static, "");
+
+			m_contract.annotation().intFuncPtrRefs.insert(function);
+		}
+		break;
+	}
+	default:
+		break;
+	}
+}

--- a/libsolidity/codegen/FuncPtrTracker.h
+++ b/libsolidity/codegen/FuncPtrTracker.h
@@ -1,0 +1,55 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Tracks function pointer references
+ */
+
+#pragma once
+
+#include <libsolidity/ast/ASTVisitor.h>
+#include <libsolidity/codegen/CompilerContext.h>
+
+namespace solidity::frontend
+{
+
+/**
+ * This class is used to add all the function pointer references in the contract and its ancestor contracts to the
+ * ContractDefinitionAnnotation::intFuncPtrRefs.  The visitor is copied from the yul codegen pipeline's usage of
+ * IRGeneratorForStatements::assignInternalFunctionIDIfNotCalledDirectly()
+ */
+class FuncPtrTracker: private ASTConstVisitor
+{
+public:
+	FuncPtrTracker(ContractDefinition const& _contract): m_contract(_contract) {}
+
+	void run()
+	{
+		for (ContractDefinition const* base: m_contract.annotation().linearizedBaseContracts)
+		{
+			base->accept(*this);
+		}
+	}
+
+private:
+	ContractDefinition const& m_contract;
+
+	void endVisit(Identifier const& _identifier);
+	void endVisit(MemberAccess const& _memberAccess);
+};
+
+}

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -40,6 +40,7 @@
 #include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/ast/ASTJsonImporter.h>
 #include <libsolidity/codegen/Compiler.h>
+#include <libsolidity/codegen/FuncPtrTracker.h>
 #include <libsolidity/formal/ModelChecker.h>
 #include <libsolidity/interface/ABI.h>
 #include <libsolidity/interface/Natspec.h>
@@ -95,6 +96,21 @@ CompilerStack::~CompilerStack()
 {
 	--g_compilerStackCounts;
 	TypeProvider::reset();
+}
+
+void CompilerStack::populateFuncPtrRefs()
+{
+	for (Source const* source: m_sourceOrder)
+	{
+		if (!source->ast)
+			continue;
+
+		for (ContractDefinition const* contract: ASTNode::filteredNodes<ContractDefinition>(source->ast->nodes()))
+		{
+			FuncPtrTracker tracker{*contract};
+			tracker.run();
+		}
+	}
 }
 
 std::optional<CompilerStack::Remapping> CompilerStack::parseRemapping(string const& _remapping)
@@ -373,6 +389,34 @@ bool CompilerStack::analyze()
 					if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
 						if (!typeChecker.checkTypeRequirements(*contract))
 							noErrors = false;
+
+		if (noErrors)
+		{
+			populateFuncPtrRefs();
+		}
+
+		if (noErrors)
+		{
+			for (Source const* source: m_sourceOrder)
+				if (source->ast)
+					for (ASTPointer<ASTNode> const& node: source->ast->nodes())
+						if (auto const* contractDefinition = dynamic_cast<ContractDefinition*>(node.get()))
+						{
+							Contract& contractState = m_contracts.at(contractDefinition->fullyQualifiedName());
+
+							contractState.contract->annotation().creationCallGraph = make_unique<CallGraph>(
+								FunctionCallGraphBuilder::buildCreationGraph(
+									*contractDefinition
+								)
+							);
+							contractState.contract->annotation().deployedCallGraph = make_unique<CallGraph>(
+								FunctionCallGraphBuilder::buildDeployedGraph(
+									*contractDefinition,
+									**contractState.contract->annotation().creationCallGraph
+								)
+							);
+						}
+		}
 
 		if (noErrors)
 		{
@@ -822,6 +866,17 @@ string const& CompilerStack::metadata(Contract const& _contract) const
 	return *_contract.metadata;
 }
 
+Json::Value const& CompilerStack::extraMetadata(string const& _contractName) const
+{
+	Contract const& contr = contract(_contractName);
+	if (m_stackState < AnalysisPerformed)
+		BOOST_THROW_EXCEPTION(CompilerError() << errinfo_comment("Analysis was not successful."));
+
+	solAssert(contr.contract, "");
+
+	return contr.extraMetadata;
+}
+
 Scanner const& CompilerStack::scanner(string const& _sourceName) const
 {
 	if (m_stackState < SourcesSet)
@@ -1101,6 +1156,7 @@ void CompilerStack::compileContract(
 			"turning off revert strings, or using libraries."
 		);
 
+	compiledContract.extraMetadata = compiler->extraMetadata();
 	_otherCompilers[compiledContract.contract] = compiler;
 }
 

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <libsolidity/analysis/FunctionCallGraph.h>
 #include <libsolidity/interface/ReadFile.h>
 #include <libsolidity/interface/OptimiserSettings.h>
 #include <libsolidity/interface/Version.h>
@@ -311,6 +312,9 @@ public:
 	/// @returns the Contract Metadata
 	std::string const& metadata(std::string const& _contractName) const;
 
+	/// @returns the contract metadata containing miscellaneous information
+	Json::Value const& extraMetadata(std::string const& _contractName) const;
+
 	/// @returns a JSON representing the estimated gas usage for contract creation, internal and external functions
 	Json::Value gasEstimates(std::string const& _contractName) const;
 
@@ -349,7 +353,11 @@ private:
 		mutable std::unique_ptr<Json::Value const> devDocumentation;
 		mutable std::unique_ptr<std::string const> sourceMapping;
 		mutable std::unique_ptr<std::string const> runtimeSourceMapping;
+		Json::Value extraMetadata; ///< Misc metadata
 	};
+
+	/// Populates the function pointer references in the AST annotation of each contract
+	void populateFuncPtrRefs();
 
 	/// Loads the missing sources from @a _ast (named @a _path) using the callback
 	/// @a m_readFile and stores the absolute paths of all imports in the AST annotations.

--- a/libsolidity/interface/OptimiserSettings.h
+++ b/libsolidity/interface/OptimiserSettings.h
@@ -38,7 +38,6 @@ struct OptimiserSettings
 	static OptimiserSettings minimal()
 	{
 		OptimiserSettings s = none();
-		s.runJumpdestRemover = true;
 		s.runPeephole = true;
 		return s;
 	}
@@ -47,9 +46,7 @@ struct OptimiserSettings
 	{
 		OptimiserSettings s;
 		s.runOrderLiterals = true;
-		s.runJumpdestRemover = true;
 		s.runPeephole = true;
-		s.runDeduplicate = true;
 		s.runCSE = true;
 		s.runConstantOptimiser = true;
 		s.runYulOptimiser = true;

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -973,6 +973,10 @@ Json::Value StandardCompiler::compileSolidity(StandardCompiler::InputsAndSetting
 		if (compilationSuccess && isArtifactRequested(_inputsAndSettings.outputSelection, file, name, "evm.gasEstimates", wildcardMatchesExperimental))
 			evmData["gasEstimates"] = compilerStack.gasEstimates(contractName);
 
+		Json::Value extraMetadata = compilerStack.extraMetadata(contractName);
+		if (compilationSuccess && !extraMetadata.empty())
+			evmData["extraMetadata"] = extraMetadata;
+
 		if (compilationSuccess && isArtifactRequested(
 			_inputsAndSettings.outputSelection,
 			file,

--- a/libsolutil/CMakeLists.txt
+++ b/libsolutil/CMakeLists.txt
@@ -34,7 +34,7 @@ set(sources
 )
 
 add_library(solutil ${sources})
-target_link_libraries(solutil PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::system)
+target_link_libraries(solutil PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::system range-v3)
 target_include_directories(solutil PUBLIC "${CMAKE_SOURCE_DIR}")
 add_dependencies(solutil solidity_BuildInfo.h)
 

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -173,6 +173,38 @@ std::map<V, K> invertMap(std::map<K, V> const& originalMap)
 	return inverseMap;
 }
 
+/// Returns a set of keys of a map.
+template <typename K, typename V>
+std::set<K> keys(std::map<K, V> const& _map)
+{
+	return applyMap(_map, [](auto const& _elem) { return _elem.first; }, std::set<K>{});
+}
+
+namespace detail
+{
+struct allow_copy {};
+}
+static constexpr auto allow_copy = detail::allow_copy{};
+
+/// @returns a reference to the entry of @a _map at @a _key, if there is one, and @a _defaultValue otherwise.
+/// Makes sure no copy is involved, unless allow_copy is passed as fourth argument.
+template<
+	typename MapType,
+	typename KeyType,
+	typename ValueType = std::decay_t<decltype(std::declval<MapType>().find(std::declval<KeyType>())->second)> const&,
+	typename AllowCopyType = void*
+>
+decltype(auto) valueOrDefault(MapType&& _map, KeyType const& _key, ValueType&& _defaultValue = {}, AllowCopyType = nullptr)
+{
+	auto it = _map.find(_key);
+	static_assert(
+		std::is_same_v<AllowCopyType, detail::allow_copy> ||
+		std::is_reference_v<decltype((it == _map.end()) ? _defaultValue : it->second)>,
+		"valueOrDefault does not allow copies by default. Pass allow_copy as additional argument, if you want to allow copies."
+	);
+	return (it == _map.end()) ? _defaultValue : it->second;
+}
+
 // String conversion functions, mainly to/from hex/nibble/byte representations.
 
 enum class WhenError

--- a/libsolutil/SetOnce.h
+++ b/libsolutil/SetOnce.h
@@ -1,0 +1,89 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libsolutil/Assertions.h>
+#include <libsolutil/Exceptions.h>
+
+#include <memory>
+#include <optional>
+#include <utility>
+
+namespace solidity::util
+{
+
+DEV_SIMPLE_EXCEPTION(BadSetOnceReassignment);
+DEV_SIMPLE_EXCEPTION(BadSetOnceAccess);
+
+/// A class that stores a value that can only be set once
+/// \tparam T the type of the stored value
+template<typename T>
+class SetOnce
+{
+public:
+	/// Initializes the class to have no stored value.
+	SetOnce() = default;
+
+	// Not copiable
+	SetOnce(SetOnce const&) = delete;
+	SetOnce(SetOnce&&) = delete;
+
+	// Not movable
+	SetOnce& operator=(SetOnce const&) = delete;
+	SetOnce& operator=(SetOnce&&) = delete;
+
+	/// @brief Sets the stored value to \p _newValue
+	/// @throws BadSetOnceReassignment when the stored value has already been set
+	/// @return `*this`
+	constexpr SetOnce& operator=(T _newValue) &
+	{
+		assertThrow(
+			!m_value.has_value(),
+			BadSetOnceReassignment,
+			"Attempt to reassign to a SetOnce that already has a value."
+		);
+
+		m_value.emplace(std::move(_newValue));
+		return *this;
+	}
+
+	/// @return A reference to the stored value. The returned reference has the same lifetime as `*this`.
+	/// @throws BadSetOnceAccess when the stored value has not yet been set
+	T const& operator*() const
+	{
+		assertThrow(
+			m_value.has_value(),
+			BadSetOnceAccess,
+			"Attempt to access the value of a SetOnce that does not have a value."
+		);
+
+		return m_value.value();
+	}
+
+	/// @return A reference to the stored value. The referent of the returned pointer has the same lifetime as `*this`.
+	/// @throws BadSetOnceAccess when the stored value has not yet been set
+	T const* operator->() const { return std::addressof(**this); }
+
+	/// @return true if a value was assigned
+	bool set() const { return m_value.has_value(); }
+
+private:
+	std::optional<T> m_value = std::nullopt;
+};
+
+}

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -79,6 +79,18 @@ AsmAnalysisInfo AsmAnalyzer::analyzeStrictAssertCorrect(Dialect const& _dialect,
 	return analysisInfo;
 }
 
+AsmAnalysisInfo AsmAnalyzer::analyzeStrictAssertCorrect(
+	Dialect const& _dialect, Object const& _object, yul::ExternalIdentifierAccess::Resolver _resolver)
+{
+	ErrorList errorList;
+	langutil::ErrorReporter errors(errorList);
+	AsmAnalysisInfo analysisInfo;
+	bool success = yul::AsmAnalyzer(analysisInfo, errors, _dialect, _resolver, _object.dataNames())
+					   .analyze(*_object.code);
+	yulAssert(success && !errors.hasErrors(), "Invalid assembly/yul code.");
+	return analysisInfo;
+}
+
 vector<YulString> AsmAnalyzer::operator()(Literal const& _literal)
 {
 	expectValidType(_literal.type, _literal.location);

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -76,6 +76,8 @@ public:
 	/// Performs analysis on the outermost code of the given object and returns the analysis info.
 	/// Asserts on failure.
 	static AsmAnalysisInfo analyzeStrictAssertCorrect(Dialect const& _dialect, Object const& _object);
+	static AsmAnalysisInfo analyzeStrictAssertCorrect(
+		Dialect const& _dialect, Object const& _object, yul::ExternalIdentifierAccess::Resolver _resolver);
 
 	std::vector<YulString> operator()(Literal const& _literal);
 	std::vector<YulString> operator()(Identifier const&);

--- a/libyul/backends/evm/AsmCodeGen.cpp
+++ b/libyul/backends/evm/AsmCodeGen.cpp
@@ -184,6 +184,7 @@ void CodeGenerator::assemble(
 	AsmAnalysisInfo& _analysisInfo,
 	evmasm::Assembly& _assembly,
 	langutil::EVMVersion _evmVersion,
+	shared_ptr<CodeTransformContext>& _context, // out
 	ExternalIdentifierAccess const& _identifierAccess,
 	bool _useNamedLabelsForFunctions,
 	bool _optimizeStackAllocation
@@ -205,6 +206,7 @@ void CodeGenerator::assemble(
 	try
 	{
 		transform(_parsedData);
+		_context = transform.context();
 	}
 	catch (StackTooDeepError const& _e)
 	{

--- a/libyul/backends/evm/AsmCodeGen.h
+++ b/libyul/backends/evm/AsmCodeGen.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <libyul/backends/evm/AbstractAssembly.h>
+#include <libyul/backends/evm/EVMCodeTransform.h>
 #include <libyul/AsmAnalysis.h>
 #include <liblangutil/SourceLocation.h>
 #include <functional>
@@ -78,6 +79,7 @@ public:
 		AsmAnalysisInfo& _analysisInfo,
 		evmasm::Assembly& _assembly,
 		langutil::EVMVersion _evmVersion,
+		std::shared_ptr<CodeTransformContext>& _context, // out
 		ExternalIdentifierAccess const& _identifierAccess = ExternalIdentifierAccess(),
 		bool _useNamedLabelsForFunctions = false,
 		bool _optimizeStackAllocation = false

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -609,6 +609,13 @@ AbstractAssembly::LabelID CodeTransform::functionEntryID(YulString _name, Scope:
 			m_assembly.newLabelId();
 		m_context->functionEntryIDs[&_function] = id;
 	}
+
+	m_context->functionInfoMap[_name].emplace(CodeTransformContext::FunctionInfo{
+		_name.str(),
+		(unsigned) _function.arguments.size(),
+		(unsigned) _function.returns.size(),
+		m_context->functionEntryIDs[&_function]});
+
 	return m_context->functionEntryIDs[&_function];
 }
 

--- a/libyul/backends/evm/EVMCodeTransform.h
+++ b/libyul/backends/evm/EVMCodeTransform.h
@@ -53,8 +53,21 @@ struct StackTooDeepError: virtual YulException
 
 struct CodeTransformContext
 {
+	struct FunctionInfo
+	{
+		std::string const name;
+		unsigned ins;
+		unsigned outs;
+		AbstractAssembly::LabelID label;
+		bool operator<(FunctionInfo const& _other) const
+		{
+			return tie(name, label, ins, outs) < tie(_other.name, _other.label, _other.ins, _other.outs);
+		}
+	};
+
 	std::map<Scope::Function const*, AbstractAssembly::LabelID> functionEntryIDs;
 	std::map<Scope::Variable const*, int> variableStackHeights;
+	std::map<YulString, std::set<FunctionInfo>> functionInfoMap;
 	std::map<Scope::Variable const*, unsigned> variableReferences;
 
 	struct JumpInfo
@@ -181,6 +194,7 @@ public:
 	void operator()(Continue const&);
 	void operator()(Leave const&);
 	void operator()(Block const& _block);
+	std::shared_ptr<Context> context() { return m_context; }
 
 private:
 	AbstractAssembly::LabelID labelFromIdentifier(Identifier const& _identifier);

--- a/libyul/optimiser/CallGraphGenerator.cpp
+++ b/libyul/optimiser/CallGraphGenerator.cpp
@@ -30,6 +30,47 @@ using namespace solidity;
 using namespace solidity::yul;
 using namespace solidity::util;
 
+namespace
+{
+// TODO: This algorithm is non-optimal.
+struct CallGraphCycleFinder
+{
+	CallGraph const& callGraph;
+	set<YulString> containedInCycle{};
+	set<YulString> visited{};
+	vector<YulString> currentPath{};
+
+	void visit(YulString _function)
+	{
+		if (visited.count(_function))
+			return;
+		if (
+			auto it = find(currentPath.begin(), currentPath.end(), _function);
+			it != currentPath.end()
+		)
+			containedInCycle.insert(it, currentPath.end());
+		else
+		{
+			currentPath.emplace_back(_function);
+			if (callGraph.functionCalls.count(_function))
+				for (auto const& child: callGraph.functionCalls.at(_function))
+					visit(child);
+			currentPath.pop_back();
+			visited.insert(_function);
+		}
+	}
+};
+}
+
+set<YulString> CallGraph::recursiveFunctions() const
+{
+	CallGraphCycleFinder cycleFinder{*this};
+	// Visiting the root only is not enough, since there may be disconnected recursive functions.
+	for (auto const& call: functionCalls)
+		cycleFinder.visit(call.first);
+	return cycleFinder.containedInCycle;
+}
+
 CallGraph CallGraphGenerator::callGraph(Block const& _ast)
 {
 	CallGraphGenerator gen;

--- a/libyul/optimiser/CallGraphGenerator.h
+++ b/libyul/optimiser/CallGraphGenerator.h
@@ -35,6 +35,10 @@ struct CallGraph
 {
 	std::map<YulString, std::set<YulString>> functionCalls;
 	std::set<YulString> functionsWithLoops;
+	/// @returns the set of functions contained in cycles in the call graph, i.e.
+	/// functions that are part of a (mutual) recursion.
+	/// Note that this does not include functions that merely call recursive functions.
+	std::set<YulString> recursiveFunctions() const;
 };
 
 /**

--- a/libyul/optimiser/Semantics.cpp
+++ b/libyul/optimiser/Semantics.cpp
@@ -103,31 +103,11 @@ map<YulString, SideEffects> SideEffectsPropagator::sideEffects(
 	// is actually a bit different from "not movable".
 
 	map<YulString, SideEffects> ret;
-	for (auto const& function: _directCallGraph.functionsWithLoops)
+	for (auto const& function: _directCallGraph.functionsWithLoops + _directCallGraph.recursiveFunctions())
 	{
 		ret[function].movable = false;
 		ret[function].sideEffectFree = false;
 		ret[function].sideEffectFreeIfNoMSize = false;
-	}
-
-	// Detect recursive functions.
-	for (auto const& call: _directCallGraph.functionCalls)
-	{
-		// TODO we could shortcut the search as soon as we find a
-		// function that has as bad side-effects as we can
-		// ever achieve via recursion.
-		auto search = [&](YulString const& _functionName, util::CycleDetector<YulString>& _cycleDetector, size_t) {
-			for (auto const& callee: _directCallGraph.functionCalls.at(_functionName))
-				if (!_dialect.builtin(callee))
-					if (_cycleDetector.run(callee))
-						return;
-		};
-		if (util::CycleDetector<YulString>(search).run(call.first))
-		{
-			ret[call.first].movable = false;
-			ret[call.first].sideEffectFree = false;
-			ret[call.first].sideEffectFreeIfNoMSize = false;
-		}
 	}
 
 	for (auto const& call: _directCallGraph.functionCalls)

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -108,6 +108,7 @@ mv solidity solc
 # Fetch jsoncpp dependency
 mkdir -p ./solc/deps/downloads/ 2>/dev/null || true
 wget -O ./solc/deps/downloads/jsoncpp-1.9.2.tar.gz https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz
+wget -O ./solc/deps/downloads/range-v3-0.11.0.tar.gz https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz
 
 # Determine version
 cd solc


### PR DESCRIPTION
* Use a selector based lowering for internal indirect function call lowering in the legacy pipeline

  This change lowers internal indirect calls as switch statements
  involving the possible tags for dispatch. The lowering resembles to
  the yul based lowering of indirect calls.

* Add FuncPtrTracker to minimize the selector

* Try to infer direct calls even if ast says indirect

* Implement the json metadata for tracking recursive functions

  This change gets the --standard-json compilation output to store
  information of functions in recursion under the "extraMetadata" field
  in the json output. This information is required by zksolc to lower
  functions in recursion correctly

* Disable libevmasm's Inliner, JumpdestRemover and BlockDeduplicator

  This change is to avoid the optimiser to potentially invalidate the
  recursion metadata

* Implement CycleFinder for solidity function ast nodes that also checks
  for potential cycles due to indirect calls

* Integrate CycleFinder in the metadata printer

* Use libyul's CallGraphGenerator to find cycles in inline assembly

* Report low level utility functions for recursive structs as recursive

* Use the Disambiguator on the inline-asm if optimizations are disabled;
  Get the Disambiguator and the AsmAnalyzer to work with inline-asm having external references

  The Disambiguator is scheduled in the optimization pipeline. We need
  it without the optimizations for the call-graph analysis to work with
  functions in different scopes having the same name.

* Force disable libevmasm's Assembly::optimise()

  Decided to do this after noticing the changes in the handling of
  optimizer.settings in older releases
