### PR TITLE
Simplify the CFG lowered from try-catch statements

### DIFF
--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -310,6 +310,11 @@ public:
 
 	RevertStrings revertStrings() const { return m_revertStrings; }
 
+	// HACK!
+	// We track the success tag here for the `TryStatement` lowering. This is to avoid the redundant status check and
+	// the conditional jump. Such patterns can confuse the zksolc translator.
+	evmasm::AssemblyItem currTryCallSuccessTag{evmasm::AssemblyItemType::UndefinedItem};
+
 private:
 	/// Updates source location set in the assembly.
 	void updateSourceLocation();

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -972,7 +972,7 @@ bool ContractCompiler::visit(TryStatement const& _tryStatement)
 	int const returnSize = static_cast<int>(_tryStatement.externalCall().annotation().type->sizeOnStack());
 
 	// Stack: [ return values] <success flag>
-	evmasm::AssemblyItem successTag = m_context.appendConditionalJump();
+	m_context << Instruction::POP;
 
 	// Catch case.
 	m_context.adjustStackOffset(-returnSize);
@@ -981,7 +981,8 @@ bool ContractCompiler::visit(TryStatement const& _tryStatement)
 
 	evmasm::AssemblyItem endTag = m_context.appendJumpToNew();
 
-	m_context << successTag;
+	solAssert(m_context.currTryCallSuccessTag.type() == AssemblyItemType::Tag, "");
+	m_context << m_context.currTryCallSuccessTag;
 	m_context.adjustStackOffset(returnSize);
 	{
 		// Success case.

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -793,7 +793,8 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 				// If this is a try call, return "<address> 1" in the success case and
 				// "0" in the error case.
 				AssemblyItem errorCase = m_context.appendConditionalJump();
-				m_context << u256(1);
+				m_context.currTryCallSuccessTag = m_context.appendJumpToNew();
+				m_context.adjustStackOffset(1);
 				m_context << errorCase;
 			}
 			else
@@ -2912,7 +2913,8 @@ void ExpressionCompiler::appendExternalFunctionCall(
 	if (_tryCall)
 	{
 		// Success branch will reach this, failure branch will directly jump to endTag.
-		m_context << u256(1);
+		m_context.currTryCallSuccessTag = m_context.appendJumpToNew();
+		m_context.adjustStackOffset(1);
 		m_context << endTag;
 	}
 }


### PR DESCRIPTION
This change is to stop zksolc taking impossible paths in the CFG during the translation.