### PR TITLE
ci: Migration from ci-runner to matterlabs-ci-runner

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -155,7 +155,7 @@ jobs:
           path: compiler-tester/reference.json
 
   benchmarks_analysis:
-    runs-on: [self-hosted, ci-runner]
+    runs-on: [matterlabs-ci-runner]
     needs: [benchmarks_candidate, benchmarks_reference]
     container:
       image: matterlabs/llvm_runner:latest

--- a/.github/workflows/build_and_release_binary_manual.yaml
+++ b/.github/workflows/build_and_release_binary_manual.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build_linux_amd64:
-    runs-on: [self-hosted, ci-runner]
+    runs-on: [matterlabs-ci-runner]
     container:
       image: matterlabs/llvm_runner:latest
       credentials:


### PR DESCRIPTION
# What ❔

Migration from deprecated self-hosted, ci-runners to matterlabs-ci-runners

We are moving from deprecated runners to stable.



## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
