### PR TITLE
Add {creation,runtime}SpillAreaSize setting to configure dedicated memory for stack spills

### DIFF
--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -75,7 +75,7 @@ void CompilerContext::addImmutable(VariableDeclaration const& _variable)
 	solAssert(_variable.immutable(), "Attempted to register a non-immutable variable as immutable.");
 	solUnimplementedAssert(_variable.annotation().type->isValueType(), "Only immutable variables of value type are supported.");
 	solAssert(m_runtimeContext, "Attempted to register an immutable variable for runtime code generation.");
-	m_immutableVariables[&_variable] = CompilerUtils::generalPurposeMemoryStart + *m_reservedMemory;
+	m_immutableVariables[&_variable] = CompilerUtils::generalPurposeMemoryStart + spillAreaSize() + *m_reservedMemory;
 	solAssert(_variable.annotation().type->memoryHeadSize() == 32, "Memory writes might overlap.");
 	*m_reservedMemory += _variable.annotation().type->memoryHeadSize();
 }
@@ -104,6 +104,10 @@ std::vector<std::string> CompilerContext::immutableVariableSlotNames(VariableDec
 	collectSlotNames(baseName, _variable.annotation().type, collectSlotNames);
 	return names;
 }
+
+size_t CompilerContext::spillAreaSize() const { return m_spillAreaSize; }
+
+void CompilerContext::setSpillAreaSize(size_t s) { m_spillAreaSize = s; }
 
 size_t CompilerContext::reservedMemory()
 {

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -92,6 +92,12 @@ public:
 	/// @returns a list of slot names referring to the stack slots of an immutable variable.
 	static std::vector<std::string> immutableVariableSlotNames(VariableDeclaration const& _variable);
 
+	/// @returns the spill area size.
+	size_t spillAreaSize() const;
+
+	/// Sets the spill area size.
+	void setSpillAreaSize(size_t s);
+
 	/// @returns the reserved memory and resets it to mark it as used.
 	size_t reservedMemory();
 
@@ -397,6 +403,9 @@ private:
 	std::map<Declaration const*, std::pair<u256, unsigned>> m_stateVariables;
 	/// Memory offsets reserved for the values of immutable variables during contract creation.
 	std::map<VariableDeclaration const*, size_t> m_immutableVariables;
+	/// Size of the spill area in bytes. Configurable via settings.  This region is placed immediately after
+	/// CompilerUtils::generalPurposeMemoryStart, and is reserved by the backend for spilling stack slots to memory.
+	size_t m_spillAreaSize = 0;
 	/// Total amount of reserved memory. Reserved memory is used to store immutable variables during contract creation.
 	/// This has to be finalized before initialiseFreeMemoryPointer() is called. That function
 	/// will reset the optional to verify that.

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -53,9 +53,10 @@ static_assert(CompilerUtils::generalPurposeMemoryStart >= CompilerUtils::zeroPoi
 
 void CompilerUtils::initialiseFreeMemoryPointer()
 {
+	size_t spillAreaSize = m_context.spillAreaSize();
 	size_t reservedMemory = m_context.reservedMemory();
-	solAssert(bigint(generalPurposeMemoryStart) + bigint(reservedMemory) < bigint(1) << 63);
-	m_context << (u256(generalPurposeMemoryStart) + reservedMemory);
+	solAssert(bigint(generalPurposeMemoryStart) + bigint(spillAreaSize) + bigint(reservedMemory) < bigint(1) << 63);
+	m_context << (u256(generalPurposeMemoryStart) + spillAreaSize + reservedMemory);
 	storeFreeMemoryPointer();
 }
 

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -129,6 +129,15 @@ void ContractCompiler::initializeContext(
 	std::map<ContractDefinition const*, std::shared_ptr<Compiler const>> const& _otherCompilers
 )
 {
+	auto spillAreaSizeFound = m_optimiserSettings.spillAreaSize.find(_contract.fullyQualifiedName());
+	if (spillAreaSizeFound != m_optimiserSettings.spillAreaSize.end())
+	{
+		// Non-null m_runtimeCompiler implies creation context.
+		size_t spillAreaSize
+			= m_runtimeCompiler ? spillAreaSizeFound->second.creation : spillAreaSizeFound->second.runtime;
+		m_context.setSpillAreaSize(spillAreaSize);
+	}
+
 	m_context.setUseABICoderV2(*_contract.sourceUnit().annotation().useABICoderV2);
 	m_context.setOtherCompilers(_otherCompilers);
 	m_context.setMostDerivedContract(_contract);

--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -108,6 +108,10 @@ public:
 	/// immutable @a _variable during contract creation.
 	size_t immutableMemoryOffset(VariableDeclaration const& _variable) const;
 	size_t immutableMemoryOffsetRelative(VariableDeclaration const& _variable) const;
+	/// @returns the spill area size.
+	size_t spillAreaSize() const;
+	/// Sets the spill area size.
+	void setSpillAreaSize(size_t);
 	/// @returns the reserved memory and resets it to mark it as used.
 	/// Intended to be used only once for initializing the free memory pointer
 	/// to after the area used for immutables.
@@ -192,6 +196,9 @@ private:
 	/// This map is empty in the legacy runtime context and may be not empty in EOF runtime context.
 	std::map<VariableDeclaration const*, size_t> m_immutableVariables;
 	std::optional<size_t> m_libraryAddressImmutableOffset;
+	/// Size of the spill area in bytes. Configurable via settings.  This region is placed immediately after
+	/// CompilerUtils::generalPurposeMemoryStart, and is reserved by the backend for spilling stack slots to memory.
+	size_t m_spillAreaSize = 0;
 	/// Total amount of reserved memory. Reserved memory is used to store
 	/// immutable variables during contract creation.
 	std::optional<size_t> m_reservedMemory = {0};

--- a/libsolidity/interface/OptimiserSettings.h
+++ b/libsolidity/interface/OptimiserSettings.h
@@ -144,6 +144,16 @@ struct OptimiserSettings
 	/// This specifies an estimate on how often each opcode in this assembly will be executed,
 	/// i.e. use a small value to optimise for size and a large value to optimise for runtime gas usage.
 	size_t expectedExecutionsPerDeployment = 200;
+	struct SpillAreaSize
+	{
+		size_t creation = 0;
+		size_t runtime = 0;
+		bool operator==(SpillAreaSize const&) const = default;
+		bool operator!=(SpillAreaSize const&) const = default;
+	};
+	/// Maps the fully qualified name of a contract to its creation and runtime spill area size (in bytes) . This is
+	/// reserved by the backend for spilling stack slots to memory.
+	std::map<std::string, SpillAreaSize> spillAreaSize;
 };
 
 }


### PR DESCRIPTION
# What ❔

A configuration to create spill area in memory
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

For the llvm backend to generate spills
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
