### PR TITLE
Track all user-defined function in ExtraMetadata's recursiveFunctions field

### DIFF
--- a/libsolidity/codegen/ExtraMetadata.h
+++ b/libsolidity/codegen/ExtraMetadata.h
@@ -37,7 +37,8 @@ class ExtraMetadataRecorder
 	CompilerContext const& m_runtimeContext;
 	/// The root JSON value of the metadata
 	/// Current mappings:
-	/// - "recursiveFunctions": array of functions involved in recursion
+	/// - "recursiveFunctions": tracks the name, tag, size of ins and outs all reachable user defined functions. This is
+	/// a misnomer for historical (zksolc/solx developement) reasons.
 	Json m_metadata;
 
 public:


### PR DESCRIPTION
# What ❔
Track all user-defined function in ExtraMetadata's recursiveFunctions field
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
This is currently the only workaround for avoiding the compile-time
explosion with big functions having multiple call-sites to it (where
solx's evmla translator codegen's it multiple times).

Yes, this makes the recursiveFunctions field a misnomer!

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
