### PR TITLE
Add an error in the presence of memory-unsafe asm and non-zero spill area size

### DIFF
--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -38,6 +38,8 @@ set(sources
 	analysis/ReferencesResolver.h
 	analysis/Scoper.cpp
 	analysis/Scoper.h
+	analysis/SpillAreaSafetyChecker.cpp
+	analysis/SpillAreaSafetyChecker.h
 	analysis/StaticAnalyzer.cpp
 	analysis/StaticAnalyzer.h
 	analysis/SyntaxChecker.cpp

--- a/libsolidity/analysis/SpillAreaSafetyChecker.cpp
+++ b/libsolidity/analysis/SpillAreaSafetyChecker.cpp
@@ -69,10 +69,10 @@ bool SpillAreaSafetyChecker::visit(InlineAssembly const& _inlineAsm)
 			"To successfully compile this contract, please check if this assembly block is memory-safe according to "
 			"the requirements at \n\n"
 			"    https://docs.soliditylang.org/en/latest/assembly.html#memory-safety\n\n"
-			"and then mark it with a memory-safe tag.\n\n"
+			"and then mark it with a memory-safe tag.\n"
 			"Alternatively, if you feel confident, you may suppress this error project-wide by "
 			"setting the EVM_DISABLE_MEMORY_SAFE_ASM_CHECK environment variable:\n\n"
 			"    EVM_DISABLE_MEMORY_SAFE_ASM_CHECK=1 <your build command>\n\n"
-			"Please be aware of the memory corruption risks described at the link above!");
+			"Please be aware of the memory corruption risks described at the link above!\n");
 	return true;
 }

--- a/libsolidity/analysis/SpillAreaSafetyChecker.cpp
+++ b/libsolidity/analysis/SpillAreaSafetyChecker.cpp
@@ -62,9 +62,12 @@ bool SpillAreaSafetyChecker::visit(InlineAssembly const& _inlineAsm)
 		m_errorReporter.typeError(
 			5726_error,
 			_inlineAsm.location(),
-			"This contract cannot be compiled due to a combination of a memory-unsafe assembly block and a stack-too-deep error. "
-			"The compiler can automatically fix the stack-too-deep error, but only in the absence of memory-unsafe assembly.\n"
-			"To successfully compile this contract, please check if this assembly block is memory-safe according to the requirements at \n\n"
+			"This contract cannot be compiled due to a combination of a memory-unsafe assembly block and a "
+			"stack-too-deep error. "
+			"The compiler can automatically fix the stack-too-deep error, but only in the absence of memory-unsafe "
+			"assembly.\n"
+			"To successfully compile this contract, please check if this assembly block is memory-safe according to "
+			"the requirements at \n\n"
 			"    https://docs.soliditylang.org/en/latest/assembly.html#memory-safety\n\n"
 			"and then mark it with a memory-safe tag.\n\n"
 			"Alternatively, if you feel confident, you may suppress this error project-wide by "

--- a/libsolidity/analysis/SpillAreaSafetyChecker.cpp
+++ b/libsolidity/analysis/SpillAreaSafetyChecker.cpp
@@ -63,6 +63,7 @@ bool SpillAreaSafetyChecker::visit(InlineAssembly const& _inlineAsm)
 			5726_error,
 			_inlineAsm.location(),
 			"memory-unsafe assembly is not supported when spilling is enabled due to stack-too-deep. Make the "
-			"assembly memory-safe to fix this.");
+			"assembly memory-safe to fix this. See "
+			"https://docs.soliditylang.org/en/latest/assembly.html#memory-safety");
 	return true;
 }

--- a/libsolidity/analysis/SpillAreaSafetyChecker.cpp
+++ b/libsolidity/analysis/SpillAreaSafetyChecker.cpp
@@ -62,15 +62,14 @@ bool SpillAreaSafetyChecker::visit(InlineAssembly const& _inlineAsm)
 		m_errorReporter.typeError(
 			5726_error,
 			_inlineAsm.location(),
-			"This contract cannot be compiled due to a stack-too-deep error that can be automatically "
-			"fixed by allocation of additional heap memory. The allocation cannot be performed safely "
-			"in the presence of memory-unsafe assembly blocks. "
-			"To successfully compile this contract, please check if this assembly block is memory-safe "
-			"according to the requirements at "
-			"https://docs.soliditylang.org/en/latest/assembly.html#memory-safety, "
-			"and then mark it with a memory-safe tag. "
-			"Alternatively, if you feel confident, you may convert this error to a warning by "
-			"setting the EVM_DISABLE_MEMORY_SAFE_ASM_CHECK environment variable. Please be aware "
-			"of the memory corruption risks described at the link above.");
+			"This contract cannot be compiled due to a combination of a memory-unsafe assembly block and a stack-too-deep error. "
+			"The compiler can automatically fix the stack-too-deep error, but only in the absence of memory-unsafe assembly.\n"
+			"To successfully compile this contract, please check if this assembly block is memory-safe according to the requirements at \n\n"
+			"    https://docs.soliditylang.org/en/latest/assembly.html#memory-safety\n\n"
+			"and then mark it with a memory-safe tag.\n\n"
+			"Alternatively, if you feel confident, you may suppress this error project-wide by "
+			"setting the EVM_DISABLE_MEMORY_SAFE_ASM_CHECK environment variable:\n\n"
+			"    EVM_DISABLE_MEMORY_SAFE_ASM_CHECK=1 <your build command>\n\n"
+			"Please be aware of the memory corruption risks described at the link above!");
 	return true;
 }

--- a/libsolidity/analysis/SpillAreaSafetyChecker.cpp
+++ b/libsolidity/analysis/SpillAreaSafetyChecker.cpp
@@ -62,8 +62,15 @@ bool SpillAreaSafetyChecker::visit(InlineAssembly const& _inlineAsm)
 		m_errorReporter.typeError(
 			5726_error,
 			_inlineAsm.location(),
-			"memory-unsafe assembly is not supported when spilling is enabled due to stack-too-deep. Make the "
-			"assembly memory-safe to fix this. See "
-			"https://docs.soliditylang.org/en/latest/assembly.html#memory-safety");
+			"This contract cannot be compiled due to a stack-too-deep error that can be automatically "
+			"fixed by allocation of additional heap memory. The allocation cannot be performed safely "
+			"in the presence of memory-unsafe assembly blocks. "
+			"To successfully compile this contract, please check if this assembly block is memory-safe "
+			"according to the requirements at "
+			"https://docs.soliditylang.org/en/latest/assembly.html#memory-safety, "
+			"and then mark it with a memory-safe tag. "
+			"Alternatively, if you feel confident, you may convert this error to a warning by "
+			"setting the EVM_DISABLE_MEMORY_SAFE_ASM_CHECK environment variable. Please be aware "
+			"of the memory corruption risks described at the link above.");
 	return true;
 }

--- a/libsolidity/analysis/SpillAreaSafetyChecker.cpp
+++ b/libsolidity/analysis/SpillAreaSafetyChecker.cpp
@@ -1,0 +1,68 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/analysis/SpillAreaSafetyChecker.h>
+
+#include <liblangutil/ErrorReporter.h>
+
+#include <libsolidity/interface/OptimiserSettings.h>
+
+#include <fmt/format.h>
+
+using namespace solidity;
+using namespace solidity::util;
+using namespace solidity::langutil;
+using namespace solidity::frontend;
+
+bool SpillAreaSafetyChecker::check(SourceUnit const& _source)
+{
+	// Don't bother walking the ast if the spill area sizes are zero.
+	bool foundNonEmptySpillArea = false;
+	for (auto i: m_optimiserSettings.spillAreaSize)
+		foundNonEmptySpillArea |= i.second.creation + i.second.runtime > 0;
+	if (!foundNonEmptySpillArea)
+		return true;
+
+	_source.accept(*this);
+	return !langutil::Error::containsErrors(m_errorReporter.errors());
+}
+
+bool SpillAreaSafetyChecker::visit(ContractDefinition const& _contr)
+{
+	// Reset spill area size.
+	m_spillAreaSize = 0;
+
+	auto found = m_optimiserSettings.spillAreaSize.find(_contr.fullyQualifiedName());
+	if (found != m_optimiserSettings.spillAreaSize.end())
+		// Consider both creation and runtime spill area size since the inline-asm might be reachable from both.
+		m_spillAreaSize = found->second.creation + found->second.runtime;
+	return true;
+}
+
+bool SpillAreaSafetyChecker::visit(InlineAssembly const& _inlineAsm)
+{
+	if (m_spillAreaSize == 0)
+		return true;
+	if (*_inlineAsm.annotation().hasMemoryEffects && !_inlineAsm.annotation().markedMemorySafe)
+		m_errorReporter.typeError(
+			5726_error,
+			_inlineAsm.location(),
+			"memory-unsafe assembly is not supported when spilling is enabled due to stack-too-deep. Make the "
+			"assembly memory-safe to fix this.");
+	return true;
+}

--- a/libsolidity/analysis/SpillAreaSafetyChecker.h
+++ b/libsolidity/analysis/SpillAreaSafetyChecker.h
@@ -1,0 +1,59 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libsolidity/ast/ASTAnnotations.h>
+#include <libsolidity/ast/ASTForward.h>
+#include <libsolidity/ast/ASTVisitor.h>
+#include <libsolidity/ast/Types.h>
+
+namespace solidity::langutil
+{
+class ErrorReporter;
+}
+
+namespace solidity::frontend
+{
+struct OptimiserSettings;
+}
+
+namespace solidity::frontend
+{
+
+class SpillAreaSafetyChecker: ASTConstVisitor
+{
+public:
+	SpillAreaSafetyChecker(OptimiserSettings const& _optConf, langutil::ErrorReporter& _errorReporter)
+		: m_optimiserSettings(_optConf), m_errorReporter(_errorReporter)
+	{
+	}
+
+	bool check(SourceUnit const& _source);
+
+private:
+	size_t m_spillAreaSize = 0;
+
+	OptimiserSettings const& m_optimiserSettings;
+	langutil::ErrorReporter& m_errorReporter;
+
+	bool visit(ContractDefinition const& _contr);
+	bool visit(InlineAssembly const& _inlineAsm);
+};
+
+}

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -586,10 +586,12 @@ bool CompilerStack::analyzeLegacy(bool _noErrorsSoFar)
 		if (source->ast && !typeChecker.checkTypeRequirements(*source->ast))
 			noErrors = false;
 
-	SpillAreaSafetyChecker spillAreaSafetyChecker(m_optimiserSettings, m_errorReporter);
-	for (Source const* source: m_sourceOrder)
-		if (source->ast && !spillAreaSafetyChecker.check(*source->ast))
-			noErrors = false;
+	if (!std::getenv("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK")) {
+		SpillAreaSafetyChecker spillAreaSafetyChecker(m_optimiserSettings, m_errorReporter);
+		for (Source const* source: m_sourceOrder)
+			if (source->ast && !spillAreaSafetyChecker.check(*source->ast))
+				noErrors = false;
+	}
 
 	if (noErrors)
 	{

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -37,6 +37,7 @@
 #include <libsolidity/analysis/NameAndTypeResolver.h>
 #include <libsolidity/analysis/PostTypeChecker.h>
 #include <libsolidity/analysis/PostTypeContractLevelChecker.h>
+#include <libsolidity/analysis/SpillAreaSafetyChecker.h>
 #include <libsolidity/analysis/StaticAnalyzer.h>
 #include <libsolidity/analysis/SyntaxChecker.h>
 #include <libsolidity/analysis/Scoper.h>
@@ -583,6 +584,11 @@ bool CompilerStack::analyzeLegacy(bool _noErrorsSoFar)
 	TypeChecker typeChecker(m_evmVersion, m_eofVersion, m_errorReporter);
 	for (Source const* source: m_sourceOrder)
 		if (source->ast && !typeChecker.checkTypeRequirements(*source->ast))
+			noErrors = false;
+
+	SpillAreaSafetyChecker spillAreaSafetyChecker(m_optimiserSettings, m_errorReporter);
+	for (Source const* source: m_sourceOrder)
+		if (source->ast && !spillAreaSafetyChecker.check(*source->ast))
 			noErrors = false;
 
 	if (noErrors)

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -586,7 +586,8 @@ bool CompilerStack::analyzeLegacy(bool _noErrorsSoFar)
 		if (source->ast && !typeChecker.checkTypeRequirements(*source->ast))
 			noErrors = false;
 
-	if (!std::getenv("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK")) {
+	if (!std::getenv("EVM_DISABLE_MEMORY_SAFE_ASM_CHECK"))
+	{
 		SpillAreaSafetyChecker spillAreaSafetyChecker(m_optimiserSettings, m_errorReporter);
 		for (Source const* source: m_sourceOrder)
 			if (source->ast && !spillAreaSafetyChecker.check(*source->ast))


### PR DESCRIPTION


# What ❔
Error handling in the presence unsafe-asm and non-zero spill area size
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔
memory-unsafe asm can potentially clobber spill area
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
